### PR TITLE
Add fmt and clippy checks in CICD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 
 jobs:
   build_and_test:
-    name: omni-ledger build and tests
+    name: omni-rust build and tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #8

Clippy warnings are treated like **errors**.