### PR TITLE
Drop non-webauthn request for given endpoint

### DIFF
--- a/src/many-macros/src/lib.rs
+++ b/src/many-macros/src/lib.rs
@@ -231,7 +231,8 @@ fn many_module_impl(attr: &TokenStream, item: TokenStream) -> Result<TokenStream
         });
         // Note: The endpoint needs to be the endpoind method name, not the trait method
         // Ex: getFromAddress and NOT get_from_address
-        field_names.clone()
+        field_names
+            .clone()
             .any(|name| endpoint_strings.contains(&name))
             .then(|| 0)
             .ok_or_else(|| {

--- a/src/many-macros/src/lib.rs
+++ b/src/many-macros/src/lib.rs
@@ -225,13 +225,13 @@ fn many_module_impl(attr: &TokenStream, item: TokenStream) -> Result<TokenStream
 
     let ns = namespace.clone();
     let validate_envelope = if let Some(endpoint) = attrs.drop_non_webauthn {
-        let mut field_names = endpoint.iter().map(|e| match &ns {
+        let field_names = endpoint.iter().map(|e| match &ns {
             Some(namespace) => format!("{}.{}", namespace, e),
             None => e.to_string(),
         });
         // Note: The endpoint needs to be the endpoind method name, not the trait method
         // Ex: getFromAddress and NOT get_from_address
-        field_names
+        field_names.clone()
             .any(|name| endpoint_strings.contains(&name))
             .then(|| 0)
             .ok_or_else(|| {

--- a/src/many/src/message/error.rs
+++ b/src/many/src/message/error.rs
@@ -153,6 +153,8 @@ many_error! {
             => "The message's timestamp is out of the accepted range of the server.",
     -1006: RequiredFieldMissing as required_field_missing(field)
             => "Field is required but missing: '{field}'.",
+    -1007: NonWebAuthnRequestDenied as non_webauthn_request_denied(endpoint)
+            => "Non-WebAuthn request denied for endpoint '{endpoint}'.",
 
     // -2000 - -2999 is for server errors.
     -2000: InternalServerError as internal_server_error()

--- a/src/many/src/server.rs
+++ b/src/many/src/server.rs
@@ -263,6 +263,12 @@ impl LowLevelManyRequestHandler for Arc<Mutex<ManyServer>> {
                 })
                 .and_then(|(message, maybe_module)| {
                     if let Some(ref m) = maybe_module {
+                        m.validate_envelope(&envelope, &message)?;
+                    }
+                    Ok((message, maybe_module))
+                })
+                .and_then(|(message, maybe_module)| {
+                    if let Some(ref m) = maybe_module {
                         m.validate(&message)?;
                     }
                     Ok((message, maybe_module))

--- a/src/many/src/server/module.rs
+++ b/src/many/src/server/module.rs
@@ -98,6 +98,14 @@ pub trait ManyModule: Sync + Send + Debug {
         Ok(())
     }
 
+    fn validate_envelope(
+        &self,
+        _envelope: &coset::CoseSign1,
+        _message: &RequestMessage,
+    ) -> Result<(), ManyError> {
+        Ok(())
+    }
+
     /// Execute a message and returns its response.
     async fn execute(&self, message: RequestMessage) -> Result<ResponseMessage, ManyError>;
 }

--- a/src/many/src/server/module/_1002_idstore.rs
+++ b/src/many/src/server/module/_1002_idstore.rs
@@ -14,7 +14,7 @@ pub use get::*;
 pub use store::*;
 pub use types::*;
 
-#[many_module(name = IdStoreModule, id = 1002, namespace = idstore, many_crate = crate)]
+#[many_module(name = IdStoreModule, id = 1002, namespace = idstore, many_crate = crate, drop_non_webauthn = [store])]
 #[cfg_attr(test, automock)]
 pub trait IdStoreModuleBackend: Send {
     fn store(&mut self, sender: &Identity, args: StoreArgs) -> Result<StoreReturns, ManyError>;


### PR DESCRIPTION
Endpoints only supporting WebAuthn requests can now be specified in the `many_module` directive.

Fixes #93 https://github.com/liftedinit/many-framework/issues/87