### PR TITLE
Feature to allow bypassing the "drop non-webauthn" mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,7 +3277,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "merk"
-version = "1.0.0"

--- a/src/many-macros/Cargo.toml
+++ b/src/many-macros/Cargo.toml
@@ -19,3 +19,5 @@ serde = "1.0.134"
 serde_tokenstream = "0.1.3"
 syn = "1.0.86"
 
+[features]
+allow_all_requests = []


### PR DESCRIPTION
This feature is only to be used for testing purposes. 

The feature allows bypassing the "drop non-webauthn" mechanism, replacing the check with a "no-op".