### PR TITLE
Refactor `tests::identity()` & add missing derive

### DIFF
--- a/src/many/src/server/module.rs
+++ b/src/many/src/server/module.rs
@@ -113,7 +113,7 @@ pub trait ManyModule: Sync + Send + Debug {
 #[cfg(test)]
 pub(crate) mod testutils {
     use crate::message::RequestMessage;
-    use crate::types::identity::tests;
+    use crate::types::identity::testing::identity;
     use crate::{ManyError, ManyModule};
 
     pub fn call_module(
@@ -141,7 +141,7 @@ pub(crate) mod testutils {
             .with_data(payload);
 
         message = if key > 0 {
-            message.with_from(tests::identity(key))
+            message.with_from(identity(key))
         } else {
             message
         };

--- a/src/many/src/server/module/_1002_idstore.rs
+++ b/src/many/src/server/module/_1002_idstore.rs
@@ -30,7 +30,7 @@ mod tests {
     use super::*;
     use crate::{
         server::module::testutils::call_module_cbor,
-        types::identity::{cose::testsutils::generate_random_eddsa_identity, tests::identity},
+        types::identity::{cose::testsutils::generate_random_eddsa_identity, testing::identity},
         Identity,
     };
     use coset::CborSerializable;

--- a/src/many/src/server/module/_1002_idstore/get.rs
+++ b/src/many/src/server/module/_1002_idstore/get.rs
@@ -12,7 +12,7 @@ pub struct GetFromRecallPhraseArgs(#[n(0)] pub RecallPhrase);
 #[cbor(map)]
 pub struct GetFromAddressArgs(#[n(0)] pub Identity);
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode)]
 #[cbor(map)]
 pub struct GetReturns{
     #[n(0)]

--- a/src/many/src/server/module/_2_ledger.rs
+++ b/src/many/src/server/module/_2_ledger.rs
@@ -33,7 +33,7 @@ mod tests {
     use super::*;
     use crate::{
         server::module::testutils::{call_module, call_module_cbor},
-        types::identity::tests::identity,
+        types::identity::testing::identity,
         types::{ledger::TokenAmount, VecOrSingle},
     };
     use minicbor::bytes::ByteVec;
@@ -55,7 +55,7 @@ mod tests {
         let mut mock = MockLedgerModuleBackend::new();
         mock.expect_info()
             .with(
-                predicate::eq(tests::identity(1)),
+                predicate::eq(identity(1)),
                 predicate::eq(InfoArgs {}),
             )
             .times(1)
@@ -86,7 +86,7 @@ mod tests {
         let mut mock = MockLedgerModuleBackend::new();
         mock.expect_balance()
             .with(
-                predicate::eq(tests::identity(1)),
+                predicate::eq(identity(1)),
                 predicate::eq(data.clone()),
             )
             .times(1)

--- a/src/many/src/server/module/_3_kvstore.rs
+++ b/src/many/src/server/module/_3_kvstore.rs
@@ -20,7 +20,7 @@ pub trait KvStoreModuleBackend: Send {
 mod tests {
     use super::*;
     use crate::server::module::testutils::{call_module, call_module_cbor};
-    use crate::types::identity::tests::identity;
+    use crate::types::identity::testing::identity;
     use minicbor::bytes::ByteVec;
     use mockall::predicate;
     use std::sync::{Arc, Mutex};
@@ -29,7 +29,7 @@ mod tests {
     fn info() {
         let mut mock = MockKvStoreModuleBackend::new();
         mock.expect_info()
-            .with(predicate::eq(tests::identity(1)), predicate::eq(InfoArg {}))
+            .with(predicate::eq(identity(1)), predicate::eq(InfoArg {}))
             .times(1)
             .return_const(Ok(InfoReturns {
                 hash: ByteVec::from(vec![9u8; 8]),
@@ -48,7 +48,7 @@ mod tests {
         };
         let mut mock = MockKvStoreModuleBackend::new();
         mock.expect_get()
-        .with(predicate::eq(tests::identity(1)), predicate::eq(data.clone()))
+        .with(predicate::eq(identity(1)), predicate::eq(data.clone()))
         .times(1).returning(|_id, _args| {
             Ok(GetReturns {
                 value: Some(ByteVec::from(vec![1, 2, 3, 4])),

--- a/src/many/src/server/module/_9_account.rs
+++ b/src/many/src/server/module/_9_account.rs
@@ -301,7 +301,7 @@ pub struct GetRolesArgs {
     pub identities: VecOrSingle<Identity>,
 }
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode)]
 #[cbor(map)]
 pub struct GetRolesReturn {
     #[n(0)]
@@ -339,7 +339,7 @@ pub struct InfoArgs {
     pub account: Identity,
 }
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode)]
 #[cbor(map)]
 pub struct InfoReturn {
     #[n(0)]
@@ -431,8 +431,7 @@ pub trait AccountModuleBackend: Send {
 #[cfg(test)]
 mod module_tests {
     use super::*;
-    use crate::server::module::testutils::call_module;
-    use crate::types::identity::tests;
+    use crate::{server::module::testutils::call_module, types::identity::testing::identity};
     use std::sync::{Arc, Mutex, RwLock};
 
     // TODO: split this to get easier to maintain tests.
@@ -505,7 +504,7 @@ mod module_tests {
 
         let module_impl = Arc::new(Mutex::new(mock));
         let module = super::AccountModule::new(module_impl);
-        let id_from = tests::identity(1);
+        let id_from = identity(1);
 
         let result: CreateReturn = minicbor::decode(
             &call_module(1, &module, "account.create", r#"{ 0: "test", 2: [0] }"#).unwrap(),

--- a/src/many/src/types/identity.rs
+++ b/src/many/src/types/identity.rs
@@ -593,11 +593,10 @@ mod serde {
     }
 }
 
-#[cfg(test)]
-pub mod tests {
-    use crate::types::identity::cose::tests::{ecdsa_256_identity, eddsa_identity};
-    use crate::Identity;
-    use std::str::FromStr;
+#[cfg(feature = "testing")]
+pub mod testing {
+
+    use super::Identity;
 
     pub fn identity(seed: u32) -> Identity {
         #[rustfmt::skip]
@@ -613,6 +612,14 @@ pub mod tests {
         ];
         Identity::from_bytes(&bytes).unwrap()
     }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::testing::identity;
+    use crate::types::identity::cose::tests::{ecdsa_256_identity, eddsa_identity};
+    use crate::Identity;
+    use std::str::FromStr;
 
     #[test]
     fn can_read_anonymous() {


### PR DESCRIPTION
- Move `identity()` behind a feature flag so it's usable outside of this
  crate
- Add missing derive for testing purpose

Required for tests in `many-framework`