### PR TITLE
Return the first role instead of the last one

### DIFF
--- a/src/many/src/server/module/_9_account.rs
+++ b/src/many/src/server/module/_9_account.rs
@@ -215,7 +215,7 @@ impl Account {
             let cp = role;
             match role.try_into() {
                 Ok(r) => {
-                    first = Some(r);
+                    first.get_or_insert(r);
                     if self.has_role(id, r) {
                         return Ok(());
                     }


### PR DESCRIPTION
The "Owner" role is last most of the time; it makes sense to display a required role other than "Owner"