### PR TITLE
Ignore hsm tests in normal cargo test

### DIFF
--- a/src/many/Cargo.toml
+++ b/src/many/Cargo.toml
@@ -75,3 +75,5 @@ raw = []
 testing = []
 # Whether to trace ManyError creation, which can be useful for debugging.
 trace_error_creation = ["backtrace"]
+# Whether to run hsm tests. This is disabled by default and only used in cargo test.
+hsm_test = []

--- a/src/many/src/hsm.rs
+++ b/src/many/src/hsm.rs
@@ -504,6 +504,7 @@ mod tests {
     /// This test will initialize a new token and generate a new ECDSA P256 keypair.
     /// The keypair will be destroyed at the end of the test, but the token will remain initialized.
     #[test]
+    #[cfg_attr(not(feature = "hsm_test"), ignore)]
     fn hsm_ecdsa_sign_verify() -> Result<(), ManyError> {
         let slot = init()?;
 
@@ -541,6 +542,7 @@ mod tests {
     /// This test will initialize a new token and generate a new ECDSA P256 keypair.
     /// The keypair will be destroyed at the end of the test, but the token will remain initialized.
     #[test]
+    #[cfg_attr(not(feature = "hsm_test"), ignore)]
     fn hsm_ecdsa_sign_p256_verify() -> Result<(), ManyError> {
         let slot = init()?;
 


### PR DESCRIPTION
It will still run on CI.

The tests are always failing if not properly configured, so it's better to ignore (but still run if the environment is good). Unfortunately, there's no way to ignore tests if an environment variable is or is not present, so the best we can do is add a feature that's used in CI but not locally.