### PR TITLE
Refactor CircleCI jobs and cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+# many-rs CI
 version: 2.1
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - lint-test-build:
-          pre-step:
+          pre-steps:
             - install-deps:
                 os: << matrix.os >>
           name: lint-test-build-v<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-${CACHE_VERSION}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - run:
@@ -62,7 +62,7 @@ jobs:
           crate: --all-features
           with_cache: false
       - save_cache:
-          key: cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: cargo-${CACHE_VERSION}-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo/bin/
             - ~/.cargo/registry/index/
@@ -82,7 +82,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-${CACHE_VERSION}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-build-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - rust/format:
@@ -56,7 +56,7 @@ jobs:
           crate: --all-features
           with_cache: false
       - save_cache:
-          key: cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: cargo-build-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo/bin/
             - ~/.cargo/registry/index/
@@ -76,7 +76,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-coverage-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - run:
@@ -93,6 +93,14 @@ jobs:
           command: grcov src -b target/debug/ -s . --keep-only 'src/**' --prefix-dir $PWD -t lcov --branch --ignore-not-existing -o coverage/report.lcov
       - codecov/upload:
           file: coverage/report.lcov
+      - save_cache:
+          key: cargo-cache-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+            - target/
   create:
     parameters:
       os:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ jobs:
           condition:
             equal: [ "linux2204", << parameters.os >> ]
           steps:
-            - checkout
             - rust/test:
                 package: --all-targets --all-features
                 with_cache: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,14 +73,6 @@ jobs:
       SOFTHSM2_CONF: /tmp/softhsm2.conf
     steps:
       - checkout
-#      - rust/install:
-#          version: nightly
-      - run:
-          name: install llvm-tools-preview
-          command: rustup component add llvm-tools-preview
-      - run:
-          name: install grcov
-          command: cargo install grcov --root target/
       - restore_cache:
           keys:
             - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
@@ -103,8 +95,6 @@ jobs:
     steps:
       - checkout
       - detect/init
-      - rust/install:
-          version: nightly
       - rust/build:
           release: true
           with_cache: false
@@ -174,6 +164,20 @@ commands:
                   sudo DEBIAN_FRONTEND=noninteractive apt -y install build-essential pkg-config clang libssl-dev libsofthsm2
                   mkdir /tmp/tokens
                   echo "directories.tokendir = /tmp/tokens" > /tmp/softhsm2.conf
+            - rust/install:
+                version: nightly
+            - run:
+                name: install llvm-tools-preview
+                command: rustup component add llvm-tools-preview
+            - run:
+                name: install grcov
+                command: cargo install grcov --root target/
+      - when:
+          condition:
+            equal: ["macos", << parameters.os >> ]
+          steps:
+            - rust/install:
+                version: nightly
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,7 @@ orbs:
   rust: circleci/rust@1.6.0
   detect: circleci/os-detect@0.3.0
 
-rust_cache_path: &rust_cache_path
-  paths:
-    - ~/.cargo
-    - target/
-
 executors:
-  linux2004:
-    machine:
-      image: ubuntu-2004:current
   linux2204:
     machine:
       image: ubuntu-2204:current
@@ -22,94 +14,49 @@ executors:
       xcode: 13.4.1
 
 jobs:
-  lint:
+  lint-test-build:
     parameters:
       os:
         type: executor
-    executor: << parameters.os >>
+    executor: : << parameters.os >>
     steps:
       - checkout
       - restore_cache:
           keys:
-            - many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-
-      - rust/install:
-          version: nightly
+            - 'cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}'
       - rust/format:
-          nightly-toolchain: true
           with_cache: false
       - rust/clippy:
           flags: --all-targets --all-features -- -D clippy::all
           with_cache: false
-
-  build:
-    parameters:
-      os:
-        type: executor
-    executor: << parameters.os >>
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-
-      - rust/install:
-          version: nightly
-      - rust/build:
-          crate: --all-features
-          with_cache: false
-      - save_cache:
-          key: many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
-  test-linux:
-    parameters:
-      os:
-        type: executor
-    executor: << parameters.os >>
-    environment:
-      PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
-      SOFTHSM2_CONF: /tmp/softhsm2.conf
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - many-rs-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-rs-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-
-            - many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-
-      - rust/install:
-          version: nightly
       - rust/test:
           package: --all-targets --all-features
           with_cache: false
-      - rust/test:
-          package: --all-features --doc
-          with_cache: false
+      - when:
+          condition:
+            matches: { pattern: "^linux.*$", value: << parameters.os >> }
+          steps:
+            - rust/test:
+                package: --all-features --doc
+                with_cache: false
+      - when:
+          condition:
+            equal: ["macos", << parameters.os >>]
+          steps:
+            - rust/test:
+                package: --all-targets --features default,client,raw,testing,trace_error_creation
+                with_cache: false
+      - rust/build:
+          crate: --all-features
+            with_cache: false
       - save_cache:
-          key: many-rs-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
-  test-macos:
-    parameters:
-      os:
-        type: executor
-    executor: << parameters.os >>
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - many-rs-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-rs-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-
-            - many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-rs-{{ .Environment.CACHE_VERSION }}-build-{{ arch }}-
-      - rust/install:
-          version: nightly
-      # There are issues with HSM and macos testing (Segfault 11). Disable HSM testing on macos for now.
-      - rust/test:
-          package: --all-targets --features default,client,raw,testing,trace_error_creation
-          with_cache: false
-      - save_cache:
-          key: many-rs-{{ .Environment.CACHE_VERSION }}-test-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
+          key: 'cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}'
+          paths:
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+            - target/
   coverage:
     parameters:
       os:
@@ -120,10 +67,6 @@ jobs:
       SOFTHSM2_CONF: /tmp/softhsm2.conf
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - many-rs-{{ .Environment.CACHE_VERSION }}-coverage-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-rs-{{ .Environment.CACHE_VERSION }}-coverage-{{ arch }}-
       - rust/install:
           version: nightly
       - run:
@@ -132,6 +75,9 @@ jobs:
       - run:
           name: install grcov
           command: cargo install grcov --root target/
+      - restore_cache:
+          keys:
+            - 'cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}'
       - run:
           name: generate test coverage
           command: cargo test --all-targets --all-features
@@ -143,9 +89,6 @@ jobs:
           command: target/bin/grcov src -b target/debug/ -s . --keep-only 'src/**' --prefix-dir $PWD -t lcov --branch --ignore-not-existing -o coverage/report.lcov
       - codecov/upload:
           file: coverage/report.lcov
-      - save_cache:
-          key: many-rs-{{ .Environment.CACHE_VERSION }}-coverage-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
   create:
     parameters:
       os:
@@ -199,19 +142,12 @@ jobs:
       - image: rust:latest
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - many-rs-{{ .Environment.CACHE_VERSION }}-audit-{{ arch }}-{{ checksum "Cargo.lock" }}
-            - many-rs-{{ .Environment.CACHE_VERSION }}-audit-{{ arch }}-
       - run:
           name: install cargo-audit
           command: cargo install cargo-audit
       - run:
           name: cargo audit
           command: cargo audit
-      - save_cache:
-          key: many-rs-{{ .Environment.CACHE_VERSION }}-audit-{{ arch }}-{{ checksum "Cargo.lock" }}
-          <<: *rust_cache_path
 
 # Re-usable commands
 commands:
@@ -239,39 +175,14 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - lint:
-          pre-steps:
+      - lint-test-build:
+          pre-step:
             - install-deps:
                 os: << matrix.os >>
-          name: lint-v<< matrix.os >>
+          name: lint-test-build-v<< matrix.os >>
           matrix:
             parameters:
-              os: [linux2004]
-      - build:
-          pre-steps:
-            - install-deps:
-                os: << matrix.os >>
-          name: build-v<< matrix.os >>
-          matrix:
-            parameters:
-              os: [linux2004, macos]
-      - test-linux:
-          pre-steps:
-            - install-deps:
-                os: << matrix.os >>
-          name: test-v<< matrix.os >>
-          matrix:
-            parameters:
-              os: [linux2004]
-          requires:
-            - build-v<< matrix.os >>
-      - test-macos:
-          name: test-v<< matrix.os >>
-          matrix:
-            parameters:
-              os: [macos]
-          requires:
-            - build-v<< matrix.os >>
+              os: [linux2204, macos]
       - coverage:
           pre-steps:
             - install-deps:
@@ -279,9 +190,9 @@ workflows:
           name: coverage-v<< matrix.os >>
           matrix:
             parameters:
-              os: [linux2004]
+              os: [linux2204]
           requires:
-            - test-v<< matrix.os >>
+            - lint-test-build-v<< matrix.os >>
   release:
     when:
       not:
@@ -294,7 +205,7 @@ workflows:
           name: create-v<< matrix.os >>
           matrix:
             parameters:
-              os: [linux2004, macos]
+              os: [linux2204, macos]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           version: nightly
       - restore_cache:
           keys:
-            - 'cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}'
+            - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/format:
           with_cache: false
       - rust/clippy:
@@ -33,7 +33,8 @@ jobs:
           with_cache: false
       - when:
           condition:
-            equal: [ "linux2204", << parameters.os >> ]
+            not:
+              equal: [ "macos", << parameters.os >> ]
           steps:
             - checkout
             - rust/test:
@@ -53,7 +54,7 @@ jobs:
           crate: --all-features
           with_cache: false
       - save_cache:
-          key: 'cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}'
+          key: cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo/bin/
             - ~/.cargo/registry/index/
@@ -70,8 +71,8 @@ jobs:
       SOFTHSM2_CONF: /tmp/softhsm2.conf
     steps:
       - checkout
-      - rust/install:
-          version: nightly
+#      - rust/install:
+#          version: nightly
       - run:
           name: install llvm-tools-preview
           command: rustup component add llvm-tools-preview
@@ -80,7 +81,7 @@ jobs:
           command: cargo install grcov --root target/
       - restore_cache:
           keys:
-            - 'cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}'
+            - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: generate test coverage
           command: cargo test --all-targets --all-features

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,23 +29,24 @@ jobs:
       - rust/clippy:
           flags: --all-targets --all-features -- -D clippy::all
           with_cache: false
-      - rust/test:
-          package: --all-targets --all-features
-          with_cache: false
       - when:
           condition:
-            matches: { pattern: "^linux.*$", value: << parameters.os >> }
+            equal: [ "linux2204", << parameters.os >> ]
           steps:
+            - checkout
             - rust/test:
-                package: --all-features --doc
+                package: --all-targets --all-features
                 with_cache: false
       - when:
           condition:
-            equal: ["macos", << parameters.os >>]
+            equal: [ "macos", << parameters.os >> ]
           steps:
             - rust/test:
                 package: --all-targets --features default,client,raw,testing,trace_error_creation
                 with_cache: false
+      - rust/test:
+          package: --all-features --doc
+          with_cache: false
       - rust/build:
           crate: --all-features
           with_cache: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
     executor: << parameters.os >>
     steps:
       - checkout
+      - rust/install:
+          version: nightly
       - restore_cache:
           keys:
             - 'cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}'
@@ -165,8 +167,8 @@ commands:
             - run:
                 name: installing linux dependencies
                 command: |
-                  sudo apt -y update
-                  sudo apt -y install build-essential pkg-config clang libssl-dev libsofthsm2
+                  sudo DEBIAN_FRONTEND=noninteractive apt -y update
+                  sudo DEBIAN_FRONTEND=noninteractive apt -y install build-essential pkg-config clang libssl-dev libsofthsm2
                   mkdir /tmp/tokens
                   echo "directories.tokendir = /tmp/tokens" > /tmp/softhsm2.conf
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,17 @@ orbs:
 
 executors:
   linux2204:
+    parameters:
+      id:
+        type: string
+        default: "linux"
     machine:
       image: ubuntu-2204:current
   macos:
+    parameters:
+      id:
+        type: string
+        default: "macos"
     macos:
       xcode: 13.4.1
 
@@ -36,7 +44,7 @@ jobs:
           with_cache: false
       - when:
           condition:
-              equal: [ "linux2204", << parameters.os >> ]
+            equal: [ "linux", << parameters.os.id >> ]
           steps:
             - checkout
             - rust/test:
@@ -44,7 +52,7 @@ jobs:
                 with_cache: false
       - when:
           condition:
-            equal: [ "macos", << parameters.os >> ]
+            equal: [ "macos", << parameters.os.id >> ]
           steps:
             - rust/test:
                 package: --all-targets --features default,client,raw,testing,trace_error_creation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       - codecov/upload:
           file: coverage/report.lcov
       - save_cache:
-          key: cargo-cache-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: cargo-coverage-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo/bin/
             - ~/.cargo/registry/index/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
+    environment:
+      PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
+      SOFTHSM2_CONF: /tmp/softhsm2.conf
     steps:
       - checkout
       - rust/install:
@@ -33,8 +36,7 @@ jobs:
           with_cache: false
       - when:
           condition:
-            not:
-              equal: [ "macos", << parameters.os >> ]
+              equal: [ "linux2204", << parameters.os >> ]
           steps:
             - checkout
             - rust/test:
@@ -209,7 +211,7 @@ workflows:
           name: create-v<< matrix.os >>
           matrix:
             parameters:
-              os: [linux2204, macos]
+              os: [linux2204]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 # many-rs CI
+# The Lifted Initiative
 version: 2.1
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-${CACHE_VERSION}-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - run:
@@ -62,7 +62,7 @@ jobs:
           crate: --all-features
           with_cache: false
       - save_cache:
-          key: cargo-${CACHE_VERSION}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo/bin/
             - ~/.cargo/registry/index/
@@ -82,7 +82,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-${CACHE_VERSION}-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - run:
@@ -185,6 +185,8 @@ workflows:
             - install-deps:
                 os: << matrix.os >>
           name: lint-test-build-v<< matrix.os >>
+          context:
+            - CACHE
           matrix:
             parameters:
               os: [linux2204, macos]
@@ -193,6 +195,8 @@ workflows:
             - install-deps:
                 os: << matrix.os >>
           name: coverage-v<< matrix.os >>
+          context:
+            - CACHE
           matrix:
             parameters:
               os: [linux2204]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,6 @@ jobs:
             - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
-      - run:
-          name: install llvm-tools-preview
-          command: rustup component add llvm-tools-preview
-      - run:
-          name: install grcov
-          command: cargo install grcov --root target/
       - rust/format:
           with_cache: false
       - rust/clippy:
@@ -86,6 +80,9 @@ jobs:
       - rust/install:
           version: nightly
       - run:
+          name: install llvm-tools-preview
+          command: rustup component add llvm-tools-preview
+      - run:
           name: generate test coverage
           command: cargo test --all-targets --all-features
           environment:
@@ -93,7 +90,7 @@ jobs:
             LLVM_PROFILE_FILE: "coverage/lcov-%p-%m.profraw"
       - run:
           name: generate coverage report
-          command: target/bin/grcov src -b target/debug/ -s . --keep-only 'src/**' --prefix-dir $PWD -t lcov --branch --ignore-not-existing -o coverage/report.lcov
+          command: grcov src -b target/debug/ -s . --keep-only 'src/**' --prefix-dir $PWD -t lcov --branch --ignore-not-existing -o coverage/report.lcov
       - codecov/upload:
           file: coverage/report.lcov
   create:
@@ -173,6 +170,9 @@ commands:
                   sudo DEBIAN_FRONTEND=noninteractive apt -y install build-essential pkg-config clang libssl-dev libsofthsm2
                   mkdir /tmp/tokens
                   echo "directories.tokendir = /tmp/tokens" > /tmp/softhsm2.conf
+            - run:
+                name: installing grcov
+                command: wget https://github.com/mozilla/grcov/releases/download/v0.8.11/grcov-x86_64-unknown-linux-gnu.tar.bz2 -O - | sudo tar -xj -C /usr/local/bin
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,17 +19,22 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
-    working_directory: ~/project/repo
     environment:
       PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
       SOFTHSM2_CONF: /tmp/softhsm2.conf
     steps:
       - checkout
-      - rust/install:
-          version: nightly
       - restore_cache:
           keys:
             - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - rust/install:
+          version: nightly
+      - run:
+          name: install llvm-tools-preview
+          command: rustup component add llvm-tools-preview
+      - run:
+          name: install grcov
+          command: cargo install grcov --root target/
       - rust/format:
           with_cache: false
       - rust/clippy:
@@ -78,6 +83,8 @@ jobs:
       - restore_cache:
           keys:
             - cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - rust/install:
+          version: nightly
       - run:
           name: generate test coverage
           command: cargo test --all-targets --all-features
@@ -166,20 +173,6 @@ commands:
                   sudo DEBIAN_FRONTEND=noninteractive apt -y install build-essential pkg-config clang libssl-dev libsofthsm2
                   mkdir /tmp/tokens
                   echo "directories.tokendir = /tmp/tokens" > /tmp/softhsm2.conf
-            - rust/install:
-                version: nightly
-            - run:
-                name: install llvm-tools-preview
-                command: rustup component add llvm-tools-preview
-            - run:
-                name: install grcov
-                command: cargo install grcov --root target/
-      - when:
-          condition:
-            equal: ["macos", << parameters.os >> ]
-          steps:
-            - rust/install:
-                version: nightly
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
                 with_cache: false
       - rust/build:
           crate: --all-features
-            with_cache: false
+          with_cache: false
       - save_cache:
           key: 'cargo-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}'
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           with_cache: false
       - when:
           condition:
-            equal: [ "linux", << parameters.os.id >> ]
+            equal: [ "linux", << parameters.os.parameters.id >> ]
           steps:
             - checkout
             - rust/test:
@@ -52,7 +52,7 @@ jobs:
                 with_cache: false
       - when:
           condition:
-            equal: [ "macos", << parameters.os.id >> ]
+            equal: [ "macos", << parameters.os.parameters.id >> ]
           steps:
             - rust/test:
                 package: --all-targets --features default,client,raw,testing,trace_error_creation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     parameters:
       os:
         type: executor
-    executor: : << parameters.os >>
+    executor: << parameters.os >>
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,17 +7,9 @@ orbs:
 
 executors:
   linux2204:
-    parameters:
-      id:
-        type: string
-        default: "linux"
     machine:
       image: ubuntu-2204:current
   macos:
-    parameters:
-      id:
-        type: string
-        default: "macos"
     macos:
       xcode: 13.4.1
 
@@ -25,7 +17,7 @@ jobs:
   lint-test-build:
     parameters:
       os:
-        type: executor
+        type: string
     executor: << parameters.os >>
     environment:
       PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
@@ -44,7 +36,7 @@ jobs:
           with_cache: false
       - when:
           condition:
-            equal: [ "linux", << parameters.os.parameters.id >> ]
+            equal: [ "linux2204", << parameters.os >> ]
           steps:
             - checkout
             - rust/test:
@@ -52,7 +44,7 @@ jobs:
                 with_cache: false
       - when:
           condition:
-            equal: [ "macos", << parameters.os.parameters.id >> ]
+            equal: [ "macos", << parameters.os >> ]
           steps:
             - rust/test:
                 package: --all-targets --features default,client,raw,testing,trace_error_creation
@@ -74,7 +66,7 @@ jobs:
   coverage:
     parameters:
       os:
-        type: executor
+        type: string
     executor: << parameters.os >>
     working_directory: ~/project/repo
     environment:
@@ -104,7 +96,7 @@ jobs:
   create:
     parameters:
       os:
-        type: executor
+        type: string
     executor: << parameters.os >>
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-build-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-build-{{ .Environment.MANY_RS_CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - rust/format:
@@ -56,7 +56,7 @@ jobs:
           crate: --all-features
           with_cache: false
       - save_cache:
-          key: cargo-build-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: cargo-build-{{ .Environment.MANY_RS_CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo/bin/
             - ~/.cargo/registry/index/
@@ -76,7 +76,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-coverage-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-coverage-{{ .Environment.MANY_RS_CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
       - rust/install:
           version: nightly
       - run:
@@ -94,7 +94,7 @@ jobs:
       - codecov/upload:
           file: coverage/report.lcov
       - save_cache:
-          key: cargo-coverage-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: cargo-coverage-{{ .Environment.MANY_RS_CACHE_VERSION }}-{{ arch }}-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo/bin/
             - ~/.cargo/registry/index/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
+    working_directory: ~/project/repo
     environment:
       PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
       SOFTHSM2_CONF: /tmp/softhsm2.conf
@@ -68,6 +69,7 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
+    working_directory: ~/project/repo
     environment:
       PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so
       SOFTHSM2_CONF: /tmp/softhsm2.conf


### PR DESCRIPTION
macOS cache size: 730Mb
Linux build-cache size: 914Mb
Linux coverage cache size: 816Mb
Total: 2.46Gb

build time from scratch: 11m48 (6-9mins build, 2mins cache upload)
build time using the cache: 5m3 (max 55s cache restore)

Cache depends on the `Cargo.lock` shasum, i.e., it will be re-created **only** if the dependencies change.


- Drop Ubuntu 20.04.
- Keep only Ubuntu 22.04 release.
- New CACHE CircleCI context with CACHE version for many-rs and many-framework

