### PR TITLE
Set CircleCI resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,11 @@ executors:
   linux2204:
     machine:
       image: ubuntu-2204:current
+    resource_class: large
   macos:
     macos:
       xcode: 13.4.1
+    resource_class: medium
 
 jobs:
   lint-test-build:
@@ -132,6 +134,7 @@ jobs:
         default: false
     docker:
       - image: cibuilds/github:0.10
+    resource_class: large
     steps:
       - attach_workspace:
           at: ~/project/artifacts
@@ -151,6 +154,7 @@ jobs:
   audit:
     docker:
       - image: rust:latest
+    resource_class: small
     steps:
       - checkout
       - run:


### PR DESCRIPTION
It is recommended to not rely on the default value.

See https://circleci.com/docs/configuration-reference#resourceclass