### PR TITLE
Migration framework

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1543,9 +1543,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.21"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a2df176f359a22aee9c8657e674f7aa54e9ba48b512a798e5ca36a1f51065c"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1716,6 +1716,26 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linkme"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab56277eeaacac09e1398bcefc113319c6c8d4fb464f11c54ba247cdb65776e"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624b78e5a5f99b2c751812a14785a2c661f894a34bc3dd1f2ec3e3fffb4605e7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "lock_api"
@@ -1938,6 +1958,8 @@ dependencies = [
 name = "many-migration"
 version = "0.1.0"
 dependencies = [
+ "linkme",
+ "minicbor",
  "serde",
  "serde_json",
  "strum",
@@ -2182,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2300,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -49,15 +49,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "ascii"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "asn1"
@@ -137,16 +137,16 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab006897723d9352f63e2b13047177c3982d8d79709d713ce7747a8f19fd1b0"
+checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
+ "async-lock",
  "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
- "once_cell",
  "parking",
  "polling",
  "slab",
@@ -157,11 +157,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -213,9 +214,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -274,9 +275,9 @@ checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
@@ -340,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
@@ -394,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytecount"
@@ -406,9 +407,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "5aec14f5d4e6e3f927cd0c81f72e5710d95ee9019fbeb4b3021193867491bfd8"
 
 [[package]]
 name = "byteorder"
@@ -430,15 +431,14 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cbor-diag"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0271d47015ca577f57ffd36cfca4f5332751840009eb09aa3bdd8dfb20815ae1"
+checksum = "2644c5bb01d8328b218301180b84ccc6f7fce031d50e30917b07ae762a185b7b"
 dependencies = [
- "base64",
  "bs58",
  "chrono",
- "half 1.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex",
+ "data-encoding",
+ "half 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint",
  "num-rational",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 
 [[package]]
 name = "cexpr"
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.19"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -561,7 +561,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor",
- "textwrap 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -597,13 +597,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -639,9 +639,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "coset"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bc3ff8849ba4144fefd28e719c1c52b63659f835746aceaa7224956a2ccacb"
+checksum = "604cb30f7b6f4fee05b9ddf88cf6d3c0af0f98d9099e6f6a050e81e7a7cb938b"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -667,12 +667,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -688,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
  "generic-array",
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
  "zeroize",
 ]
@@ -738,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn",
@@ -754,7 +753,7 @@ checksum = "399fa7fc41ab7163fc49d5c2613b582b04bbf2d5342fcb1946fc1efd5b71193c"
 dependencies = [
  "async-trait",
  "atty",
- "clap 3.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 3.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "console",
  "cucumber-codegen",
  "cucumber-expressions",
@@ -826,12 +825,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
- "darling_core 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "darling_macro 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_core 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -850,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -875,14 +874,20 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
- "darling_core 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_core 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "debug-helper"
@@ -956,7 +961,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2",
  "quote",
  "syn",
@@ -1010,11 +1015,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
- "block-buffer 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-common",
  "subtle",
 ]
@@ -1081,7 +1086,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
  "zeroize",
 ]
@@ -1103,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -1135,7 +1140,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
 ]
 
@@ -1183,25 +1188,24 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
 [[package]]
 name = "fragile"
-version = "1.2.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1214,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1224,15 +1228,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1241,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-lite"
@@ -1262,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1273,21 +1277,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1324,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1404,15 +1408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -1494,7 +1498,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1539,9 +1543,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "41a2df176f359a22aee9c8657e674f7aa54e9ba48b512a798e5ca36a1f51065c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1582,11 +1586,10 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -1652,24 +1655,24 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1694,9 +1697,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libloading"
@@ -1716,9 +1719,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1742,7 +1745,7 @@ dependencies = [
  "atty",
  "base64",
  "cbor-diag",
- "clap 3.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 3.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "coset",
  "hex",
  "many-client",
@@ -1832,26 +1835,19 @@ dependencies = [
 name = "many-identity"
 version = "0.1.0"
 dependencies = [
- "asn1 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base32",
  "coset",
  "crc-any",
- "cryptoki",
- "ed25519",
- "ed25519-dalek",
  "hex",
  "many-error",
  "many-identity",
  "minicbor",
  "once_cell",
- "p256",
- "pkcs8 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_test",
- "sha2 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature",
  "static_assertions",
  "tracing",
@@ -1882,8 +1878,8 @@ dependencies = [
  "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_test",
- "sha2 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature",
  "tracing",
 ]
@@ -1902,7 +1898,7 @@ dependencies = [
  "many-protocol",
  "once_cell",
  "p256",
- "sha2 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature",
  "tracing",
 ]
@@ -1922,7 +1918,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "sha2 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -1936,6 +1932,16 @@ dependencies = [
  "serde",
  "serde_tokenstream",
  "syn",
+]
+
+[[package]]
+name = "many-migration"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "strum",
+ "tracing",
 ]
 
 [[package]]
@@ -2005,12 +2011,12 @@ dependencies = [
  "num-traits",
  "once_cell",
  "proptest",
- "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2056,7 +2062,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature",
  "smol",
@@ -2086,12 +2092,6 @@ dependencies = [
  "serde",
  "serde_test",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -2134,30 +2134,30 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-sys",
+ "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mockall"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
+checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -2170,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
+checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -2234,6 +2234,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2318,9 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 dependencies = [
  "parking_lot_core",
 ]
@@ -2333,9 +2343,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2365,9 +2375,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -2378,9 +2388,15 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -2411,15 +2427,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2437,7 +2453,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2502,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
@@ -2554,22 +2570,22 @@ checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
  "der 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkcs5",
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "spki 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -2641,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -2710,7 +2726,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2730,7 +2746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2744,11 +2760,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2766,7 +2782,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2806,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64",
  "bytes",
@@ -2822,10 +2838,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -2914,7 +2930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2932,7 +2948,7 @@ dependencies = [
  "hmac 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "salsa20",
- "sha2 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2984,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "separator"
@@ -2996,18 +3012,18 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3016,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -3027,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7f3621491f256177206a7c2152c17f322c0d0b30af05359088172437d29e25"
+checksum = "641666500e4e6fba7b91b73651a375cb53579468ab3c38389289b802797cad94"
 dependencies = [
  "serde",
 ]
@@ -3072,13 +3088,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3095,11 +3111,11 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak",
 ]
 
@@ -3144,7 +3160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3158,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol"
@@ -3232,6 +3248,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -3254,9 +3273,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3373,24 +3392,24 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3408,21 +3427,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny_http"
@@ -3454,9 +3484,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3464,7 +3494,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3496,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3525,9 +3554,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -3537,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3548,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3569,11 +3598,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
+ "nu-ansi-term",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3612,54 +3641,53 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 
 [[package]]
 name = "valuable"
@@ -3735,9 +3763,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3745,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -3760,9 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3772,9 +3800,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3782,9 +3810,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3795,15 +3823,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3866,12 +3894,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_gnu 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnu 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3880,10 +3929,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3892,16 +3953,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,6 +1929,7 @@ dependencies = [
 name = "many-migration"
 version = "0.1.0"
 dependencies = [
+ "minicbor",
  "serde",
  "serde_json",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkme"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab56277eeaacac09e1398bcefc113319c6c8d4fb464f11c54ba247cdb65776e"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624b78e5a5f99b2c751812a14785a2c661f894a34bc3dd1f2ec3e3fffb4605e7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +1949,7 @@ dependencies = [
 name = "many-migration"
 version = "0.1.0"
 dependencies = [
+ "linkme",
  "minicbor",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,6 +1926,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "many-migration"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "strum",
+ "tracing",
+]
+
+[[package]]
 name = "many-mock"
 version = "0.1.0"
 dependencies = [
@@ -2977,18 +2987,18 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2997,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -3213,6 +3223,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -3506,9 +3519,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -3518,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3529,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "src/many-identity-hsm",
     "src/many-identity-webauthn",
     "src/many-macros",
+    "src/many-migration",
     "src/many-mock",
     "src/many-modules",
     "src/many-protocol",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -13,11 +13,12 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-RUST_VERSION = "1.62.0"
+RUST_VERSION = "nightly"
 
 rust_register_toolchains(
     edition = "2021",
     version = RUST_VERSION,
+    iso_date = "2022-10-31",
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
@@ -46,6 +47,7 @@ crates_repository(
         "//src/many-identity-hsm:Cargo.toml",
         "//src/many-identity-webauthn:Cargo.toml",
         "//src/many-macros:Cargo.toml",
+        "//src/many-migration:Cargo.toml",
         "//src/many-mock:Cargo.toml",
         "//src/many-modules:Cargo.toml",
         "//src/many-protocol:Cargo.toml",

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "323f3107b6376e33f21bfc03eb48dbe6d2d461994f3175f4784dda74ae946abc",
+  "checksum": "0ff0a9d310f42f2e515794b9cfdd4e93964520346cba504b51757501ef1b8072",
   "crates": {
     "aes 0.7.5": {
       "name": "aes",
@@ -8188,13 +8188,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "hyper 0.14.21": {
+    "hyper 0.14.22": {
       "name": "hyper",
-      "version": "0.14.21",
+      "version": "0.14.22",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hyper/0.14.21/download",
-          "sha256": "41a2df176f359a22aee9c8657e674f7aa54e9ba48b512a798e5ca36a1f51065c"
+          "url": "https://crates.io/api/v1/crates/hyper/0.14.22/download",
+          "sha256": "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
         }
       },
       "targets": [
@@ -8295,7 +8295,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.21"
+        "version": "0.14.22"
       },
       "license": "MIT"
     },
@@ -8334,11 +8334,11 @@
               "target": "bytes"
             },
             {
-              "id": "hyper 0.14.21",
+              "id": "hyper 0.14.22",
               "target": "hyper"
             },
             {
-              "id": "native-tls 0.2.10",
+              "id": "native-tls 0.2.11",
               "target": "native_tls"
             },
             {
@@ -9115,6 +9115,104 @@
         "version": "0.5.6"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "linkme 0.3.5": {
+      "name": "linkme",
+      "version": "0.3.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/linkme/0.3.5/download",
+          "sha256": "cab56277eeaacac09e1398bcefc113319c6c8d4fb464f11c54ba247cdb65776e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "linkme",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "linkme",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "used_linker"
+        ],
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "linkme-impl 0.3.5",
+              "target": "linkme_impl"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.3.5"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "linkme-impl 0.3.5": {
+      "name": "linkme-impl",
+      "version": "0.3.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/linkme-impl/0.3.5/download",
+          "sha256": "624b78e5a5f99b2c751812a14785a2c661f894a34bc3dd1f2ec3e3fffb4605e7"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "linkme_impl",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "linkme_impl",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "used_linker"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.47",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.21",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.103",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.3.5"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "lock_api 0.4.9": {
       "name": "lock_api",
@@ -10072,6 +10170,10 @@
         "deps": {
           "common": [
             {
+              "id": "minicbor 0.18.0",
+              "target": "minicbor"
+            },
+            {
               "id": "serde 1.0.147",
               "target": "serde"
             },
@@ -10086,6 +10188,15 @@
             {
               "id": "tracing 0.1.37",
               "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "deps_dev": {
+          "common": [
+            {
+              "id": "linkme 0.3.5",
+              "target": "linkme"
             }
           ],
           "selects": {}
@@ -11147,13 +11258,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "native-tls 0.2.10": {
+    "native-tls 0.2.11": {
       "name": "native-tls",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/native-tls/0.2.10/download",
-          "sha256": "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+          "url": "https://crates.io/api/v1/crates/native-tls/0.2.11/download",
+          "sha256": "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
         }
       },
       "targets": [
@@ -11190,7 +11301,7 @@
         "deps": {
           "common": [
             {
-              "id": "native-tls 0.2.10",
+              "id": "native-tls 0.2.11",
               "target": "build_script_build"
             }
           ],
@@ -11244,7 +11355,7 @@
           }
         },
         "edition": "2015",
-        "version": "0.2.10"
+        "version": "0.2.11"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11879,13 +11990,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "num_cpus 1.13.1": {
+    "num_cpus 1.14.0": {
       "name": "num_cpus",
-      "version": "1.13.1",
+      "version": "1.14.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num_cpus/1.13.1/download",
-          "sha256": "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+          "url": "https://crates.io/api/v1/crates/num_cpus/1.14.0/download",
+          "sha256": "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
         }
       },
       "targets": [
@@ -11925,7 +12036,7 @@
           }
         },
         "edition": "2015",
-        "version": "1.13.1"
+        "version": "1.14.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -14784,7 +14895,7 @@
                 "target": "http_body"
               },
               {
-                "id": "hyper 0.14.21",
+                "id": "hyper 0.14.22",
                 "target": "hyper"
               },
               {
@@ -14804,7 +14915,7 @@
                 "target": "mime"
               },
               {
-                "id": "native-tls 0.2.10",
+                "id": "native-tls 0.2.11",
                 "target": "native_tls",
                 "alias": "native_tls_crate"
               },
@@ -18306,7 +18417,7 @@
               "target": "mio"
             },
             {
-              "id": "num_cpus 1.13.1",
+              "id": "num_cpus 1.14.0",
               "target": "num_cpus"
             },
             {
@@ -18456,7 +18567,7 @@
         "deps": {
           "common": [
             {
-              "id": "native-tls 0.2.10",
+              "id": "native-tls 0.2.11",
               "target": "native_tls"
             },
             {

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "96bfd12abe2f51eab7bb016ce4713d5d3c2ca5d8c266c79d48f60a89039bb9e4",
+  "checksum": "323f3107b6376e33f21bfc03eb48dbe6d2d461994f3175f4784dda74ae946abc",
   "crates": {
     "aes 0.7.5": {
       "name": "aes",
@@ -47,7 +47,7 @@
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
               {
-                "id": "cpufeatures 0.2.4",
+                "id": "cpufeatures 0.2.5",
                 "target": "cpufeatures"
               }
             ]
@@ -58,13 +58,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "aho-corasick 0.7.18": {
+    "aho-corasick 0.7.19": {
       "name": "aho-corasick",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/aho-corasick/0.7.18/download",
-          "sha256": "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+          "url": "https://crates.io/api/v1/crates/aho-corasick/0.7.19/download",
+          "sha256": "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
         }
       },
       "targets": [
@@ -100,7 +100,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.7.18"
+        "version": "0.7.19"
       },
       "license": "Unlicense/MIT"
     },
@@ -148,13 +148,13 @@
       },
       "license": "MIT"
     },
-    "anyhow 1.0.63": {
+    "anyhow 1.0.66": {
       "name": "anyhow",
-      "version": "1.0.63",
+      "version": "1.0.66",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.63/download",
-          "sha256": "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.66/download",
+          "sha256": "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
         }
       },
       "targets": [
@@ -195,14 +195,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.63",
+              "id": "anyhow 1.0.66",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.63"
+        "version": "1.0.66"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -211,13 +211,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ascii 1.0.0": {
+    "ascii 1.1.0": {
       "name": "ascii",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ascii/1.0.0/download",
-          "sha256": "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
+          "url": "https://crates.io/api/v1/crates/ascii/1.1.0/download",
+          "sha256": "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
         }
       },
       "targets": [
@@ -240,13 +240,14 @@
           "**"
         ],
         "crate_features": [
+          "alloc",
           "default",
           "std"
         ],
         "edition": "2015",
-        "version": "1.0.0"
+        "version": "1.1.0"
       },
-      "license": "Apache-2.0 / MIT"
+      "license": "Apache-2.0 OR MIT"
     },
     "asn1 0.10.0": {
       "name": "asn1",
@@ -421,7 +422,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -429,7 +430,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -479,7 +480,7 @@
               "target": "event_listener"
             },
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             }
           ],
@@ -537,7 +538,7 @@
               "target": "futures_lite"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
@@ -599,7 +600,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "async-lock 2.5.0",
+              "id": "async-lock 2.6.0",
               "target": "async_lock"
             },
             {
@@ -632,13 +633,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-io 1.8.0": {
+    "async-io 1.10.0": {
       "name": "async-io",
-      "version": "1.8.0",
+      "version": "1.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-io/1.8.0/download",
-          "sha256": "0ab006897723d9352f63e2b13047177c3982d8d79709d713ce7747a8f19fd1b0"
+          "url": "https://crates.io/api/v1/crates/async-io/1.10.0/download",
+          "sha256": "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
         }
       },
       "targets": [
@@ -675,8 +676,12 @@
         "deps": {
           "common": [
             {
-              "id": "async-io 1.8.0",
+              "id": "async-io 1.10.0",
               "target": "build_script_build"
+            },
+            {
+              "id": "async-lock 2.6.0",
+              "target": "async_lock"
             },
             {
               "id": "concurrent-queue 1.2.4",
@@ -691,15 +696,11 @@
               "target": "log"
             },
             {
-              "id": "once_cell 1.13.1",
-              "target": "once_cell"
-            },
-            {
               "id": "parking 2.0.0",
               "target": "parking"
             },
             {
-              "id": "polling 2.3.0",
+              "id": "polling 2.4.0",
               "target": "polling"
             },
             {
@@ -718,7 +719,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
@@ -731,7 +732,7 @@
           }
         },
         "edition": "2018",
-        "version": "1.8.0"
+        "version": "1.10.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -749,13 +750,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-lock 2.5.0": {
+    "async-lock 2.6.0": {
       "name": "async-lock",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-lock/2.5.0/download",
-          "sha256": "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+          "url": "https://crates.io/api/v1/crates/async-lock/2.6.0/download",
+          "sha256": "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
         }
       },
       "targets": [
@@ -782,12 +783,16 @@
             {
               "id": "event-listener 2.5.3",
               "target": "event_listener"
+            },
+            {
+              "id": "futures-lite 1.12.0",
+              "target": "futures_lite"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.5.0"
+        "version": "2.6.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -834,7 +839,7 @@
         "deps": {
           "common": [
             {
-              "id": "async-io 1.8.0",
+              "id": "async-io 1.10.0",
               "target": "async_io"
             },
             {
@@ -930,18 +935,18 @@
               "target": "futures_lite"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             }
           ],
           "selects": {
             "cfg(unix)": [
               {
-                "id": "async-io 1.8.0",
+                "id": "async-io 1.10.0",
                 "target": "async_io"
               },
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               },
               {
@@ -1011,7 +1016,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -1019,7 +1024,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -1067,13 +1072,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-trait 0.1.57": {
+    "async-trait 0.1.58": {
       "name": "async-trait",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-trait/0.1.57/download",
-          "sha256": "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+          "url": "https://crates.io/api/v1/crates/async-trait/0.1.58/download",
+          "sha256": "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
         }
       },
       "targets": [
@@ -1110,11 +1115,11 @@
         "deps": {
           "common": [
             {
-              "id": "async-trait 0.1.57",
+              "id": "async-trait 0.1.58",
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -1122,14 +1127,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.57"
+        "version": "0.1.58"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1210,7 +1215,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
@@ -1352,13 +1357,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "base64 0.13.0": {
+    "base64 0.13.1": {
       "name": "base64",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/base64/0.13.0/download",
-          "sha256": "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+          "url": "https://crates.io/api/v1/crates/base64/0.13.1/download",
+          "sha256": "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
         }
       },
       "targets": [
@@ -1385,7 +1390,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.13.0"
+        "version": "0.13.1"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -1502,7 +1507,7 @@
               "target": "cexpr"
             },
             {
-              "id": "clang-sys 1.3.3",
+              "id": "clang-sys 1.4.0",
               "target": "clang_sys"
             },
             {
@@ -1510,7 +1515,7 @@
               "target": "clap"
             },
             {
-              "id": "env_logger 0.9.0",
+              "id": "env_logger 0.9.1",
               "target": "env_logger"
             },
             {
@@ -1530,7 +1535,7 @@
               "target": "peeking_take_while"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -1684,13 +1689,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "block-buffer 0.10.2": {
+    "block-buffer 0.10.3": {
       "name": "block-buffer",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.2/download",
-          "sha256": "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.3/download",
+          "sha256": "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
         }
       },
       "targets": [
@@ -1722,7 +1727,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.2"
+        "version": "0.10.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1905,7 +1910,7 @@
               "target": "futures_lite"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             }
           ],
@@ -1997,13 +2002,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "bumpalo 3.11.0": {
+    "bumpalo 3.11.1": {
       "name": "bumpalo",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bumpalo/3.11.0/download",
-          "sha256": "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+          "url": "https://crates.io/api/v1/crates/bumpalo/3.11.1/download",
+          "sha256": "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
         }
       },
       "targets": [
@@ -2029,7 +2034,7 @@
           "default"
         ],
         "edition": "2021",
-        "version": "3.11.0"
+        "version": "3.11.1"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -2066,13 +2071,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "bytemuck 1.12.1": {
+    "bytemuck 1.12.2": {
       "name": "bytemuck",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytemuck/1.12.1/download",
-          "sha256": "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+          "url": "https://crates.io/api/v1/crates/bytemuck/1.12.2/download",
+          "sha256": "5aec14f5d4e6e3f927cd0c81f72e5710d95ee9019fbeb4b3021193867491bfd8"
         }
       },
       "targets": [
@@ -2095,7 +2100,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.12.1"
+        "version": "1.12.2"
       },
       "license": "Zlib OR Apache-2.0 OR MIT"
     },
@@ -2206,13 +2211,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "cbor-diag 0.1.9": {
+    "cbor-diag 0.1.11": {
       "name": "cbor-diag",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cbor-diag/0.1.9/download",
-          "sha256": "0271d47015ca577f57ffd36cfca4f5332751840009eb09aa3bdd8dfb20815ae1"
+          "url": "https://crates.io/api/v1/crates/cbor-diag/0.1.11/download",
+          "sha256": "2644c5bb01d8328b218301180b84ccc6f7fce031d50e30917b07ae762a185b7b"
         }
       },
       "targets": [
@@ -2237,10 +2242,6 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.13.0",
-              "target": "base64"
-            },
-            {
               "id": "bs58 0.4.0",
               "target": "bs58"
             },
@@ -2249,12 +2250,12 @@
               "target": "chrono"
             },
             {
-              "id": "half 1.8.2",
-              "target": "half"
+              "id": "data-encoding 2.3.2",
+              "target": "data_encoding"
             },
             {
-              "id": "hex 0.4.3",
-              "target": "hex"
+              "id": "half 2.1.0",
+              "target": "half"
             },
             {
               "id": "nom 5.1.2",
@@ -2277,28 +2278,28 @@
               "target": "separator"
             },
             {
-              "id": "url 2.2.2",
+              "id": "url 2.3.1",
               "target": "url"
             },
             {
-              "id": "uuid 1.1.2",
+              "id": "uuid 1.2.1",
               "target": "uuid"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.1.9"
+        "edition": "2021",
+        "version": "0.1.11"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cc 1.0.73": {
+    "cc 1.0.74": {
       "name": "cc",
-      "version": "1.0.73",
+      "version": "1.0.74",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.73/download",
-          "sha256": "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+          "url": "https://crates.io/api/v1/crates/cc/1.0.74/download",
+          "sha256": "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
         }
       },
       "targets": [
@@ -2333,9 +2334,9 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.73"
+        "version": "1.0.74"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "cexpr 0.6.0": {
       "name": "cexpr",
@@ -2537,7 +2538,7 @@
               "target": "ciborium_ll"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             }
           ],
@@ -2673,13 +2674,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clang-sys 1.3.3": {
+    "clang-sys 1.4.0": {
       "name": "clang-sys",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clang-sys/1.3.3/download",
-          "sha256": "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+          "url": "https://crates.io/api/v1/crates/clang-sys/1.4.0/download",
+          "sha256": "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
         }
       },
       "targets": [
@@ -2728,7 +2729,7 @@
         "deps": {
           "common": [
             {
-              "id": "clang-sys 1.3.3",
+              "id": "clang-sys 1.4.0",
               "target": "build_script_build"
             },
             {
@@ -2736,7 +2737,7 @@
               "target": "glob"
             },
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             },
             {
@@ -2747,7 +2748,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.3.3"
+        "version": "1.4.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2822,7 +2823,7 @@
               "target": "textwrap"
             },
             {
-              "id": "unicode-width 0.1.9",
+              "id": "unicode-width 0.1.10",
               "target": "unicode_width"
             },
             {
@@ -2844,13 +2845,13 @@
       },
       "license": "MIT"
     },
-    "clap 3.2.19": {
+    "clap 3.2.23": {
       "name": "clap",
-      "version": "3.2.19",
+      "version": "3.2.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/3.2.19/download",
-          "sha256": "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
+          "url": "https://crates.io/api/v1/crates/clap/3.2.23/download",
+          "sha256": "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
         }
       },
       "targets": [
@@ -2915,7 +2916,7 @@
               "target": "indexmap"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
@@ -2927,7 +2928,7 @@
               "target": "termcolor"
             },
             {
-              "id": "textwrap 0.15.0",
+              "id": "textwrap 0.16.0",
               "target": "textwrap"
             }
           ],
@@ -2943,7 +2944,7 @@
           ],
           "selects": {}
         },
-        "version": "3.2.19"
+        "version": "3.2.23"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2989,7 +2990,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -2997,7 +2998,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -3039,7 +3040,7 @@
         "deps": {
           "common": [
             {
-              "id": "os_str_bytes 6.3.0",
+              "id": "os_str_bytes 6.3.1",
               "target": "os_str_bytes"
             }
           ],
@@ -3092,13 +3093,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "console 0.15.1": {
+    "console 0.15.2": {
       "name": "console",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/console/0.15.1/download",
-          "sha256": "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+          "url": "https://crates.io/api/v1/crates/console/0.15.2/download",
+          "sha256": "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
         }
       },
       "targets": [
@@ -3128,19 +3129,19 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.132",
-              "target": "libc"
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
             },
             {
-              "id": "once_cell 1.13.1",
-              "target": "once_cell"
+              "id": "libc 0.2.137",
+              "target": "libc"
             },
             {
               "id": "terminal_size 0.1.17",
               "target": "terminal_size"
             },
             {
-              "id": "unicode-width 0.1.9",
+              "id": "unicode-width 0.1.10",
               "target": "unicode_width"
             }
           ],
@@ -3158,7 +3159,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.15.1"
+        "version": "0.15.2"
       },
       "license": "MIT"
     },
@@ -3263,7 +3264,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             }
           ],
@@ -3333,13 +3334,13 @@
       },
       "license": "MIT / Apache-2.0"
     },
-    "coset 0.3.2": {
+    "coset 0.3.3": {
       "name": "coset",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/coset/0.3.2/download",
-          "sha256": "55bc3ff8849ba4144fefd28e719c1c52b63659f835746aceaa7224956a2ccacb"
+          "url": "https://crates.io/api/v1/crates/coset/0.3.3/download",
+          "sha256": "604cb30f7b6f4fee05b9ddf88cf6d3c0af0f98d9099e6f6a050e81e7a7cb938b"
         }
       },
       "targets": [
@@ -3375,17 +3376,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.2"
+        "version": "0.3.3"
       },
       "license": "Apache-2.0"
     },
-    "cpufeatures 0.2.4": {
+    "cpufeatures 0.2.5": {
       "name": "cpufeatures",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cpufeatures/0.2.4/download",
-          "sha256": "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
+          "url": "https://crates.io/api/v1/crates/cpufeatures/0.2.5/download",
+          "sha256": "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
         }
       },
       "targets": [
@@ -3412,26 +3413,26 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.4"
+        "version": "0.2.5"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3482,13 +3483,13 @@
       },
       "license": "MIT"
     },
-    "crossbeam-utils 0.8.11": {
+    "crossbeam-utils 0.8.12": {
       "name": "crossbeam-utils",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.11/download",
-          "sha256": "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.12/download",
+          "sha256": "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
         }
       },
       "targets": [
@@ -3524,7 +3525,6 @@
         ],
         "crate_features": [
           "default",
-          "once_cell",
           "std"
         ],
         "deps": {
@@ -3534,18 +3534,14 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.11",
+              "id": "crossbeam-utils 0.8.12",
               "target": "build_script_build"
-            },
-            {
-              "id": "once_cell 1.13.1",
-              "target": "once_cell"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.11"
+        "version": "0.8.12"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3659,7 +3655,7 @@
               "target": "generic_array"
             },
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             },
             {
@@ -3915,13 +3911,13 @@
       },
       "license": "Apache-2.0"
     },
-    "ctor 0.1.23": {
+    "ctor 0.1.26": {
       "name": "ctor",
-      "version": "0.1.23",
+      "version": "0.1.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ctor/0.1.23/download",
-          "sha256": "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+          "url": "https://crates.io/api/v1/crates/ctor/0.1.26/download",
+          "sha256": "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
         }
       },
       "targets": [
@@ -3950,14 +3946,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.23"
+        "version": "0.1.26"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -4003,11 +3999,11 @@
               "target": "atty"
             },
             {
-              "id": "clap 3.2.19",
+              "id": "clap 3.2.23",
               "target": "clap"
             },
             {
-              "id": "console 0.15.1",
+              "id": "console 0.15.2",
               "target": "console"
             },
             {
@@ -4019,7 +4015,7 @@
               "target": "either"
             },
             {
-              "id": "futures 0.3.24",
+              "id": "futures 0.3.25",
               "target": "futures"
             },
             {
@@ -4035,7 +4031,7 @@
               "target": "inventory"
             },
             {
-              "id": "itertools 0.10.3",
+              "id": "itertools 0.10.5",
               "target": "itertools"
             },
             {
@@ -4043,7 +4039,7 @@
               "target": "linked_hash_map"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
@@ -4057,7 +4053,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.57",
+              "id": "async-trait 0.1.58",
               "target": "async_trait"
             },
             {
@@ -4118,11 +4114,11 @@
               "target": "inflections"
             },
             {
-              "id": "itertools 0.10.3",
+              "id": "itertools 0.10.5",
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -4134,7 +4130,7 @@
               "target": "regex"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             },
             {
@@ -4340,13 +4336,13 @@
       },
       "license": "MIT"
     },
-    "darling 0.14.1": {
+    "darling 0.14.2": {
       "name": "darling",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling/0.14.1/download",
-          "sha256": "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+          "url": "https://crates.io/api/v1/crates/darling/0.14.2/download",
+          "sha256": "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
         }
       },
       "targets": [
@@ -4375,7 +4371,7 @@
         "deps": {
           "common": [
             {
-              "id": "darling_core 0.14.1",
+              "id": "darling_core 0.14.2",
               "target": "darling_core"
             }
           ],
@@ -4385,13 +4381,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "darling_macro 0.14.1",
+              "id": "darling_macro 0.14.2",
               "target": "darling_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.14.1"
+        "version": "0.14.2"
       },
       "license": "MIT"
     },
@@ -4438,7 +4434,7 @@
               "target": "ident_case"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -4450,7 +4446,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -4461,13 +4457,13 @@
       },
       "license": "MIT"
     },
-    "darling_core 0.14.1": {
+    "darling_core 0.14.2": {
       "name": "darling_core",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling_core/0.14.1/download",
-          "sha256": "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+          "url": "https://crates.io/api/v1/crates/darling_core/0.14.2/download",
+          "sha256": "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
         }
       },
       "targets": [
@@ -4504,7 +4500,7 @@
               "target": "ident_case"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -4516,14 +4512,14 @@
               "target": "strsim"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.1"
+        "version": "0.14.2"
       },
       "license": "MIT"
     },
@@ -4566,7 +4562,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -4577,13 +4573,13 @@
       },
       "license": "MIT"
     },
-    "darling_macro 0.14.1": {
+    "darling_macro 0.14.2": {
       "name": "darling_macro",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling_macro/0.14.1/download",
-          "sha256": "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+          "url": "https://crates.io/api/v1/crates/darling_macro/0.14.2/download",
+          "sha256": "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
         }
       },
       "targets": [
@@ -4608,7 +4604,7 @@
         "deps": {
           "common": [
             {
-              "id": "darling_core 0.14.1",
+              "id": "darling_core 0.14.2",
               "target": "darling_core"
             },
             {
@@ -4616,14 +4612,50 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.1"
+        "version": "0.14.2"
+      },
+      "license": "MIT"
+    },
+    "data-encoding 2.3.2": {
+      "name": "data-encoding",
+      "version": "2.3.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/data-encoding/2.3.2/download",
+          "sha256": "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "data_encoding",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "data_encoding",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "alloc"
+        ],
+        "edition": "2018",
+        "version": "2.3.2"
       },
       "license": "MIT"
     },
@@ -4792,7 +4824,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -4800,7 +4832,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -4938,7 +4970,7 @@
               "target": "darling"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -4946,7 +4978,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -4988,11 +5020,11 @@
         "deps": {
           "common": [
             {
-              "id": "darling 0.14.1",
+              "id": "darling 0.14.2",
               "target": "darling"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -5000,7 +5032,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -5046,7 +5078,7 @@
               "target": "derive_builder_core"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -5092,7 +5124,7 @@
               "target": "derive_builder_core"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -5143,7 +5175,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -5151,7 +5183,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -5195,13 +5227,13 @@
       },
       "license": "MIT"
     },
-    "digest 0.10.3": {
+    "digest 0.10.5": {
       "name": "digest",
-      "version": "0.10.3",
+      "version": "0.10.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/digest/0.10.3/download",
-          "sha256": "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+          "url": "https://crates.io/api/v1/crates/digest/0.10.5/download",
+          "sha256": "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
         }
       },
       "targets": [
@@ -5235,7 +5267,7 @@
         "deps": {
           "common": [
             {
-              "id": "block-buffer 0.10.2",
+              "id": "block-buffer 0.10.3",
               "target": "block_buffer"
             },
             {
@@ -5250,7 +5282,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.3"
+        "version": "0.10.5"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5528,7 +5560,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde",
               "alias": "serde_crate"
             },
@@ -5647,7 +5679,7 @@
               "target": "pkcs8"
             },
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             },
             {
@@ -5770,13 +5802,13 @@
       },
       "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
     },
-    "env_logger 0.9.0": {
+    "env_logger 0.9.1": {
       "name": "env_logger",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/env_logger/0.9.0/download",
-          "sha256": "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+          "url": "https://crates.io/api/v1/crates/env_logger/0.9.1/download",
+          "sha256": "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
         }
       },
       "targets": [
@@ -5831,9 +5863,9 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.9.0"
+        "version": "0.9.1"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "event-listener 2.5.3": {
       "name": "event-listener",
@@ -5943,7 +5975,7 @@
         "deps": {
           "common": [
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             },
             {
@@ -6006,7 +6038,7 @@
               "alias": "az_crate"
             },
             {
-              "id": "bytemuck 1.12.1",
+              "id": "bytemuck 1.12.2",
               "target": "bytemuck"
             },
             {
@@ -6193,13 +6225,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "form_urlencoded 1.0.1": {
+    "form_urlencoded 1.1.0": {
       "name": "form_urlencoded",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/form_urlencoded/1.0.1/download",
-          "sha256": "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+          "url": "https://crates.io/api/v1/crates/form_urlencoded/1.1.0/download",
+          "sha256": "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
         }
       },
       "targets": [
@@ -6224,28 +6256,24 @@
         "deps": {
           "common": [
             {
-              "id": "matches 0.1.9",
-              "target": "matches"
-            },
-            {
-              "id": "percent-encoding 2.1.0",
+              "id": "percent-encoding 2.2.0",
               "target": "percent_encoding"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.1"
+        "version": "1.1.0"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
-    "fragile 1.2.1": {
+    "fragile 2.0.0": {
       "name": "fragile",
-      "version": "1.2.1",
+      "version": "2.0.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fragile/1.2.1/download",
-          "sha256": "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
+          "url": "https://crates.io/api/v1/crates/fragile/2.0.0/download",
+          "sha256": "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
         }
       },
       "targets": [
@@ -6268,17 +6296,17 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.2.1"
+        "version": "2.0.0"
       },
       "license": "Apache-2.0"
     },
-    "futures 0.3.24": {
+    "futures 0.3.25": {
       "name": "futures",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures/0.3.24/download",
-          "sha256": "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+          "url": "https://crates.io/api/v1/crates/futures/0.3.25/download",
+          "sha256": "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
         }
       },
       "targets": [
@@ -6311,48 +6339,48 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.24",
+              "id": "futures-channel 0.3.25",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             },
             {
-              "id": "futures-executor 0.3.24",
+              "id": "futures-executor 0.3.25",
               "target": "futures_executor"
             },
             {
-              "id": "futures-io 0.3.24",
+              "id": "futures-io 0.3.25",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.24",
+              "id": "futures-sink 0.3.25",
               "target": "futures_sink"
             },
             {
-              "id": "futures-task 0.3.24",
+              "id": "futures-task 0.3.25",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.24",
+              "id": "futures-util 0.3.25",
               "target": "futures_util"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-channel 0.3.24": {
+    "futures-channel 0.3.25": {
       "name": "futures-channel",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-channel/0.3.24/download",
-          "sha256": "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+          "url": "https://crates.io/api/v1/crates/futures-channel/0.3.25/download",
+          "sha256": "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
         }
       },
       "targets": [
@@ -6396,22 +6424,22 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.24",
+              "id": "futures-channel 0.3.25",
               "target": "build_script_build"
             },
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.24",
+              "id": "futures-sink 0.3.25",
               "target": "futures_sink"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6420,13 +6448,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-core 0.3.24": {
+    "futures-core 0.3.25": {
       "name": "futures-core",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-core/0.3.24/download",
-          "sha256": "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+          "url": "https://crates.io/api/v1/crates/futures-core/0.3.25/download",
+          "sha256": "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
         }
       },
       "targets": [
@@ -6468,14 +6496,14 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6484,13 +6512,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-executor 0.3.24": {
+    "futures-executor 0.3.25": {
       "name": "futures-executor",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-executor/0.3.24/download",
-          "sha256": "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+          "url": "https://crates.io/api/v1/crates/futures-executor/0.3.25/download",
+          "sha256": "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
         }
       },
       "targets": [
@@ -6518,32 +6546,32 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             },
             {
-              "id": "futures-task 0.3.24",
+              "id": "futures-task 0.3.25",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.24",
+              "id": "futures-util 0.3.25",
               "target": "futures_util"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-io 0.3.24": {
+    "futures-io 0.3.25": {
       "name": "futures-io",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-io/0.3.24/download",
-          "sha256": "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+          "url": "https://crates.io/api/v1/crates/futures-io/0.3.25/download",
+          "sha256": "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
         }
       },
       "targets": [
@@ -6570,7 +6598,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6619,11 +6647,11 @@
               "target": "fastrand"
             },
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.24",
+              "id": "futures-io 0.3.25",
               "target": "futures_io"
             },
             {
@@ -6650,13 +6678,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "futures-macro 0.3.24": {
+    "futures-macro 0.3.25": {
       "name": "futures-macro",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-macro/0.3.24/download",
-          "sha256": "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+          "url": "https://crates.io/api/v1/crates/futures-macro/0.3.25/download",
+          "sha256": "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
         }
       },
       "targets": [
@@ -6681,7 +6709,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -6689,24 +6717,24 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-sink 0.3.24": {
+    "futures-sink 0.3.25": {
       "name": "futures-sink",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-sink/0.3.24/download",
-          "sha256": "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+          "url": "https://crates.io/api/v1/crates/futures-sink/0.3.25/download",
+          "sha256": "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
         }
       },
       "targets": [
@@ -6734,17 +6762,17 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-task 0.3.24": {
+    "futures-task 0.3.25": {
       "name": "futures-task",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-task/0.3.24/download",
-          "sha256": "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+          "url": "https://crates.io/api/v1/crates/futures-task/0.3.25/download",
+          "sha256": "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
         }
       },
       "targets": [
@@ -6785,14 +6813,14 @@
         "deps": {
           "common": [
             {
-              "id": "futures-task 0.3.24",
+              "id": "futures-task 0.3.25",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6801,13 +6829,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-util 0.3.24": {
+    "futures-util 0.3.25": {
       "name": "futures-util",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-util/0.3.24/download",
-          "sha256": "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+          "url": "https://crates.io/api/v1/crates/futures-util/0.3.25/download",
+          "sha256": "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
         }
       },
       "targets": [
@@ -6859,27 +6887,27 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.24",
+              "id": "futures-channel 0.3.25",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.24",
+              "id": "futures-io 0.3.25",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.24",
+              "id": "futures-sink 0.3.25",
               "target": "futures_sink"
             },
             {
-              "id": "futures-task 0.3.24",
+              "id": "futures-task 0.3.25",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.24",
+              "id": "futures-util 0.3.25",
               "target": "build_script_build"
             },
             {
@@ -6905,13 +6933,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "futures-macro 0.3.24",
+              "id": "futures-macro 0.3.25",
               "target": "futures_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7058,7 +7086,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ]
@@ -7074,13 +7102,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "getrandom 0.2.7": {
+    "getrandom 0.2.8": {
       "name": "getrandom",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/getrandom/0.2.7/download",
-          "sha256": "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+          "url": "https://crates.io/api/v1/crates/getrandom/0.2.8/download",
+          "sha256": "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
         }
       },
       "targets": [
@@ -7121,14 +7149,14 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.7"
+        "version": "0.2.8"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7192,7 +7220,7 @@
               "target": "textwrap"
             },
             {
-              "id": "thiserror 1.0.33",
+              "id": "thiserror 1.0.37",
               "target": "thiserror"
             }
           ],
@@ -7225,15 +7253,15 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.85",
+              "id": "serde_json 1.0.87",
               "target": "serde_json"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -7273,7 +7301,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -7281,7 +7309,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -7360,7 +7388,7 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 0.7.18",
+              "id": "aho-corasick 0.7.19",
               "target": "aho_corasick"
             },
             {
@@ -7472,7 +7500,7 @@
               "target": "ff"
             },
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             },
             {
@@ -7487,13 +7515,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "h2 0.3.14": {
+    "h2 0.3.15": {
       "name": "h2",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/h2/0.3.14/download",
-          "sha256": "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+          "url": "https://crates.io/api/v1/crates/h2/0.3.15/download",
+          "sha256": "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
         }
       },
       "targets": [
@@ -7526,15 +7554,15 @@
               "target": "fnv"
             },
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.24",
+              "id": "futures-sink 0.3.25",
               "target": "futures_sink"
             },
             {
-              "id": "futures-util 0.3.24",
+              "id": "futures-util 0.3.25",
               "target": "futures_util"
             },
             {
@@ -7550,22 +7578,22 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.7.3",
+              "id": "tokio-util 0.7.4",
               "target": "tokio_util"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.14"
+        "version": "0.3.15"
       },
       "license": "MIT"
     },
@@ -7713,7 +7741,7 @@
         "deps": {
           "common": [
             {
-              "id": "unicode-segmentation 1.9.0",
+              "id": "unicode-segmentation 1.10.0",
               "target": "unicode_segmentation"
             }
           ],
@@ -7794,7 +7822,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             }
           ],
@@ -7920,7 +7948,7 @@
         "deps": {
           "common": [
             {
-              "id": "digest 0.10.3",
+              "id": "digest 0.10.5",
               "target": "digest"
             }
           ],
@@ -7970,7 +7998,7 @@
               "target": "fnv"
             },
             {
-              "id": "itoa 1.0.3",
+              "id": "itoa 1.0.4",
               "target": "itoa"
             }
           ],
@@ -8160,13 +8188,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "hyper 0.14.20": {
+    "hyper 0.14.21": {
       "name": "hyper",
-      "version": "0.14.20",
+      "version": "0.14.21",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hyper/0.14.20/download",
-          "sha256": "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+          "url": "https://crates.io/api/v1/crates/hyper/0.14.21/download",
+          "sha256": "41a2df176f359a22aee9c8657e674f7aa54e9ba48b512a798e5ca36a1f51065c"
         }
       },
       "targets": [
@@ -8204,19 +8232,19 @@
               "target": "bytes"
             },
             {
-              "id": "futures-channel 0.3.24",
+              "id": "futures-channel 0.3.25",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             },
             {
-              "id": "futures-util 0.3.24",
+              "id": "futures-util 0.3.25",
               "target": "futures_util"
             },
             {
-              "id": "h2 0.3.14",
+              "id": "h2 0.3.15",
               "target": "h2"
             },
             {
@@ -8236,7 +8264,7 @@
               "target": "httpdate"
             },
             {
-              "id": "itoa 1.0.3",
+              "id": "itoa 1.0.4",
               "target": "itoa"
             },
             {
@@ -8248,7 +8276,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             },
             {
@@ -8256,7 +8284,7 @@
               "target": "tower_service"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             },
             {
@@ -8267,7 +8295,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.20"
+        "version": "0.14.21"
       },
       "license": "MIT"
     },
@@ -8306,7 +8334,7 @@
               "target": "bytes"
             },
             {
-              "id": "hyper 0.14.20",
+              "id": "hyper 0.14.21",
               "target": "hyper"
             },
             {
@@ -8314,7 +8342,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             },
             {
@@ -8362,13 +8390,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "idna 0.2.3": {
+    "idna 0.3.0": {
       "name": "idna",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/idna/0.2.3/download",
-          "sha256": "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+          "url": "https://crates.io/api/v1/crates/idna/0.3.0/download",
+          "sha256": "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
         }
       },
       "targets": [
@@ -8393,24 +8421,20 @@
         "deps": {
           "common": [
             {
-              "id": "matches 0.1.9",
-              "target": "matches"
-            },
-            {
               "id": "unicode-bidi 0.3.8",
               "target": "unicode_bidi"
             },
             {
-              "id": "unicode-normalization 0.1.21",
+              "id": "unicode-normalization 0.1.22",
               "target": "unicode_normalization"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.3"
+        "version": "0.3.0"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "ignore 0.4.18": {
       "name": "ignore",
@@ -8443,7 +8467,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-utils 0.8.11",
+              "id": "crossbeam-utils 0.8.12",
               "target": "crossbeam_utils"
             },
             {
@@ -8675,7 +8699,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "ctor 0.1.23",
+              "id": "ctor 0.1.26",
               "target": "ctor"
             },
             {
@@ -8725,13 +8749,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "itertools 0.10.3": {
+    "itertools 0.10.5": {
       "name": "itertools",
-      "version": "0.10.3",
+      "version": "0.10.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/itertools/0.10.3/download",
-          "sha256": "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+          "url": "https://crates.io/api/v1/crates/itertools/0.10.5/download",
+          "sha256": "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
         }
       },
       "targets": [
@@ -8768,17 +8792,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.3"
+        "version": "0.10.5"
       },
       "license": "MIT/Apache-2.0"
     },
-    "itoa 1.0.3": {
+    "itoa 1.0.4": {
       "name": "itoa",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/itoa/1.0.3/download",
-          "sha256": "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+          "url": "https://crates.io/api/v1/crates/itoa/1.0.4/download",
+          "sha256": "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
         }
       },
       "targets": [
@@ -8801,17 +8825,17 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.3"
+        "version": "1.0.4"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "js-sys 0.3.59": {
+    "js-sys 0.3.60": {
       "name": "js-sys",
-      "version": "0.3.59",
+      "version": "0.3.60",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/js-sys/0.3.59/download",
-          "sha256": "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+          "url": "https://crates.io/api/v1/crates/js-sys/0.3.60/download",
+          "sha256": "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
         }
       },
       "targets": [
@@ -8836,14 +8860,14 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen 0.2.82",
+              "id": "wasm-bindgen 0.2.83",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.59"
+        "version": "0.3.60"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -8946,13 +8970,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.132": {
+    "libc 0.2.137": {
       "name": "libc",
-      "version": "0.2.132",
+      "version": "0.2.137",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.132/download",
-          "sha256": "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.137/download",
+          "sha256": "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
         }
       },
       "targets": [
@@ -8993,14 +9017,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.132"
+        "version": "0.2.137"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9092,13 +9116,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "lock_api 0.4.8": {
+    "lock_api 0.4.9": {
       "name": "lock_api",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/lock_api/0.4.8/download",
-          "sha256": "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+          "url": "https://crates.io/api/v1/crates/lock_api/0.4.9/download",
+          "sha256": "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
         }
       },
       "targets": [
@@ -9135,7 +9159,7 @@
         "deps": {
           "common": [
             {
-              "id": "lock_api 0.4.8",
+              "id": "lock_api 0.4.9",
               "target": "build_script_build"
             },
             {
@@ -9146,7 +9170,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.8"
+        "version": "0.4.9"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9256,7 +9280,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.63",
+              "id": "anyhow 1.0.66",
               "target": "anyhow"
             },
             {
@@ -9264,19 +9288,19 @@
               "target": "atty"
             },
             {
-              "id": "base64 0.13.0",
+              "id": "base64 0.13.1",
               "target": "base64"
             },
             {
-              "id": "cbor-diag 0.1.9",
+              "id": "cbor-diag 0.1.11",
               "target": "cbor_diag"
             },
             {
-              "id": "clap 3.2.19",
+              "id": "clap 3.2.23",
               "target": "clap"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -9296,19 +9320,19 @@
               "target": "rpassword"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             },
             {
-              "id": "tracing-subscriber 0.3.15",
+              "id": "tracing-subscriber 0.3.16",
               "target": "tracing_subscriber"
             },
             {
-              "id": "url 2.2.2",
+              "id": "url 2.3.1",
               "target": "url"
             }
           ],
@@ -9357,7 +9381,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.63",
+              "id": "anyhow 1.0.66",
               "target": "anyhow"
             },
             {
@@ -9365,11 +9389,11 @@
               "target": "base32"
             },
             {
-              "id": "base64 0.13.0",
+              "id": "base64 0.13.1",
               "target": "base64"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -9433,11 +9457,11 @@
               "target": "regex"
             },
             {
-              "id": "reqwest 0.11.11",
+              "id": "reqwest 0.11.12",
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
@@ -9457,11 +9481,11 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
@@ -9471,7 +9495,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.57",
+              "id": "async-trait 0.1.58",
               "target": "async_trait"
             },
             {
@@ -9511,7 +9535,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -9519,7 +9543,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -9622,32 +9646,16 @@
         "deps": {
           "common": [
             {
-              "id": "asn1 0.11.0",
-              "target": "asn1"
-            },
-            {
               "id": "base32 0.4.0",
               "target": "base32"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
               "id": "crc-any 2.4.3",
               "target": "crc_any"
-            },
-            {
-              "id": "cryptoki 0.3.0",
-              "target": "cryptoki"
-            },
-            {
-              "id": "ed25519 1.5.2",
-              "target": "ed25519"
-            },
-            {
-              "id": "ed25519-dalek 1.0.1",
-              "target": "ed25519_dalek"
             },
             {
               "id": "hex 0.4.3",
@@ -9658,31 +9666,19 @@
               "target": "minicbor"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
-              "id": "p256 0.9.0",
-              "target": "p256"
-            },
-            {
-              "id": "pkcs8 0.8.0",
-              "target": "pkcs8"
-            },
-            {
-              "id": "rand 0.7.3",
-              "target": "rand"
-            },
-            {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "sha2 0.10.3",
+              "id": "sha2 0.10.6",
               "target": "sha2"
             },
             {
-              "id": "sha3 0.10.2",
+              "id": "sha3 0.10.6",
               "target": "sha3"
             },
             {
@@ -9694,7 +9690,7 @@
               "target": "static_assertions"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
@@ -9707,7 +9703,7 @@
               "target": "proptest"
             },
             {
-              "id": "serde_test 1.0.144",
+              "id": "serde_test 1.0.147",
               "target": "serde_test"
             }
           ],
@@ -9761,7 +9757,7 @@
               "target": "base32"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -9789,7 +9785,7 @@
               "target": "minicbor"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
@@ -9810,15 +9806,15 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "sha2 0.10.3",
+              "id": "sha2 0.10.6",
               "target": "sha2"
             },
             {
-              "id": "sha3 0.10.2",
+              "id": "sha3 0.10.6",
               "target": "sha3"
             },
             {
@@ -9826,7 +9822,7 @@
               "target": "signature"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
@@ -9839,7 +9835,7 @@
               "target": "proptest"
             },
             {
-              "id": "serde_test 1.0.144",
+              "id": "serde_test 1.0.147",
               "target": "serde_test"
             }
           ],
@@ -9880,7 +9876,7 @@
               "target": "asn1"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -9892,7 +9888,7 @@
               "target": "hex"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
@@ -9900,7 +9896,7 @@
               "target": "p256"
             },
             {
-              "id": "sha2 0.10.3",
+              "id": "sha2 0.10.6",
               "target": "sha2"
             },
             {
@@ -9908,7 +9904,7 @@
               "target": "signature"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
@@ -9945,11 +9941,11 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.13.0",
+              "id": "base64 0.13.1",
               "target": "base64"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -9957,23 +9953,23 @@
               "target": "minicbor"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.85",
+              "id": "serde_json 1.0.87",
               "target": "serde_json"
             },
             {
-              "id": "sha2 0.10.3",
+              "id": "sha2 0.10.6",
               "target": "sha2"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
@@ -10023,7 +10019,7 @@
               "target": "inflections"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -10031,7 +10027,7 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
@@ -10039,8 +10035,57 @@
               "target": "serde_tokenstream"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": null
+    },
+    "many-migration 0.1.0": {
+      "name": "many-migration",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "many_migration",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "many_migration",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.147",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.87",
+              "target": "serde_json"
+            },
+            {
+              "id": "strum 0.24.1",
+              "target": "strum"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
             }
           ],
           "selects": {}
@@ -10076,11 +10121,11 @@
         "deps": {
           "common": [
             {
-              "id": "cbor-diag 0.1.9",
+              "id": "cbor-diag 0.1.11",
               "target": "cbor_diag"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -10088,7 +10133,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
@@ -10109,15 +10154,15 @@
               "target": "cucumber"
             },
             {
-              "id": "futures 0.3.24",
+              "id": "futures 0.3.25",
               "target": "futures"
             },
             {
-              "id": "serde_json 1.0.85",
+              "id": "serde_json 1.0.87",
               "target": "serde_json"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             }
           ],
@@ -10127,7 +10172,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.57",
+              "id": "async-trait 0.1.58",
               "target": "async_trait"
             }
           ],
@@ -10163,7 +10208,7 @@
         "deps": {
           "common": [
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -10192,15 +10237,15 @@
         "deps_dev": {
           "common": [
             {
-              "id": "cbor-diag 0.1.9",
+              "id": "cbor-diag 0.1.11",
               "target": "cbor_diag"
             },
             {
-              "id": "mockall 0.11.2",
+              "id": "mockall 0.11.3",
               "target": "mockall"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
@@ -10218,7 +10263,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.57",
+              "id": "async-trait 0.1.58",
               "target": "async_trait"
             },
             {
@@ -10258,11 +10303,11 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.13.0",
+              "id": "base64 0.13.1",
               "target": "base64"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -10286,23 +10331,15 @@
               "target": "num_traits"
             },
             {
-              "id": "proptest 1.0.0",
-              "target": "proptest"
-            },
-            {
-              "id": "reqwest 0.11.11",
-              "target": "reqwest"
-            },
-            {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.85",
+              "id": "serde_json 1.0.87",
               "target": "serde_json"
             },
             {
-              "id": "sha2 0.10.3",
+              "id": "sha2 0.10.6",
               "target": "sha2"
             },
             {
@@ -10310,8 +10347,12 @@
               "target": "signature"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
+            },
+            {
+              "id": "url 2.3.1",
+              "target": "url"
             }
           ],
           "selects": {}
@@ -10319,8 +10360,12 @@
         "deps_dev": {
           "common": [
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
+            },
+            {
+              "id": "proptest 1.0.0",
+              "target": "proptest"
             }
           ],
           "selects": {}
@@ -10369,7 +10414,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.63",
+              "id": "anyhow 1.0.66",
               "target": "anyhow"
             },
             {
@@ -10381,11 +10426,11 @@
               "target": "base32"
             },
             {
-              "id": "base64 0.13.0",
+              "id": "base64 0.13.1",
               "target": "base64"
             },
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -10437,7 +10482,7 @@
               "target": "num_traits"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
@@ -10457,19 +10502,19 @@
               "target": "regex"
             },
             {
-              "id": "reqwest 0.11.11",
+              "id": "reqwest 0.11.12",
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.85",
+              "id": "serde_json 1.0.87",
               "target": "serde_json"
             },
             {
-              "id": "sha2 0.10.3",
+              "id": "sha2 0.10.6",
               "target": "sha2"
             },
             {
@@ -10493,11 +10538,11 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
@@ -10510,7 +10555,7 @@
               "target": "proptest"
             },
             {
-              "id": "semver 1.0.13",
+              "id": "semver 1.0.14",
               "target": "semver"
             },
             {
@@ -10524,7 +10569,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.57",
+              "id": "async-trait 0.1.58",
               "target": "async_trait"
             },
             {
@@ -10571,7 +10616,7 @@
         "deps": {
           "common": [
             {
-              "id": "coset 0.3.2",
+              "id": "coset 0.3.3",
               "target": "coset"
             },
             {
@@ -10599,7 +10644,7 @@
               "target": "proptest"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             }
           ],
@@ -10608,7 +10653,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "serde_test 1.0.144",
+              "id": "serde_test 1.0.147",
               "target": "serde_test"
             }
           ],
@@ -10627,39 +10672,6 @@
         "version": "0.1.0"
       },
       "license": null
-    },
-    "matches 0.1.9": {
-      "name": "matches",
-      "version": "0.1.9",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/matches/0.1.9/download",
-          "sha256": "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "matches",
-            "crate_root": "lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "matches",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.1.9"
-      },
-      "license": "MIT"
     },
     "memchr 2.5.0": {
       "name": "memchr",
@@ -10884,7 +10896,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -10892,7 +10904,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -10939,13 +10951,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "mio 0.8.4": {
+    "mio 0.8.5": {
       "name": "mio",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/mio/0.8.4/download",
-          "sha256": "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+          "url": "https://crates.io/api/v1/crates/mio/0.8.5/download",
+          "sha256": "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
         }
       },
       "targets": [
@@ -10983,7 +10995,7 @@
           "selects": {
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               },
               {
@@ -10993,30 +11005,30 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.36.1",
+                "id": "windows-sys 0.42.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.8.4"
+        "version": "0.8.5"
       },
       "license": "MIT"
     },
-    "mockall 0.11.2": {
+    "mockall 0.11.3": {
       "name": "mockall",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/mockall/0.11.2/download",
-          "sha256": "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
+          "url": "https://crates.io/api/v1/crates/mockall/0.11.3/download",
+          "sha256": "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
         }
       },
       "targets": [
@@ -11049,7 +11061,7 @@
               "target": "downcast"
             },
             {
-              "id": "fragile 1.2.1",
+              "id": "fragile 2.0.0",
               "target": "fragile"
             },
             {
@@ -11071,23 +11083,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "mockall_derive 0.11.2",
+              "id": "mockall_derive 0.11.3",
               "target": "mockall_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.11.2"
+        "version": "0.11.3"
       },
       "license": "MIT/Apache-2.0"
     },
-    "mockall_derive 0.11.2": {
+    "mockall_derive 0.11.3": {
       "name": "mockall_derive",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/mockall_derive/0.11.2/download",
-          "sha256": "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
+          "url": "https://crates.io/api/v1/crates/mockall_derive/0.11.3/download",
+          "sha256": "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
         }
       },
       "targets": [
@@ -11116,7 +11128,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -11124,14 +11136,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.11.2"
+        "version": "0.11.3"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -11189,7 +11201,7 @@
                 "target": "lazy_static"
               },
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               },
               {
@@ -11211,7 +11223,7 @@
                 "target": "log"
               },
               {
-                "id": "openssl 0.10.41",
+                "id": "openssl 0.10.42",
                 "target": "openssl"
               },
               {
@@ -11219,7 +11231,7 @@
                 "target": "openssl_probe"
               },
               {
-                "id": "openssl-sys 0.9.75",
+                "id": "openssl-sys 0.9.77",
                 "target": "openssl_sys"
               }
             ],
@@ -11456,6 +11468,55 @@
       },
       "license": "Apache-2.0"
     },
+    "nu-ansi-term 0.46.0": {
+      "name": "nu-ansi-term",
+      "version": "0.46.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/nu-ansi-term/0.46.0/download",
+          "sha256": "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "nu_ansi_term",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "nu_ansi_term",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "overload 0.1.1",
+              "target": "overload"
+            }
+          ],
+          "selects": {
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.46.0"
+      },
+      "license": "MIT"
+    },
     "num-bigint 0.4.3": {
       "name": "num-bigint",
       "version": "0.4.3",
@@ -11567,7 +11628,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -11575,7 +11636,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -11857,7 +11918,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ]
@@ -11901,7 +11962,7 @@
           "selects": {
             "cfg(any(target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\"))": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ]
@@ -11912,13 +11973,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "once_cell 1.13.1": {
+    "once_cell 1.16.0": {
       "name": "once_cell",
-      "version": "1.13.1",
+      "version": "1.16.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/once_cell/1.13.1/download",
-          "sha256": "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+          "url": "https://crates.io/api/v1/crates/once_cell/1.16.0/download",
+          "sha256": "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
         }
       },
       "targets": [
@@ -11951,14 +12012,14 @@
         "deps": {
           "common": [
             {
-              "id": "parking_lot_core 0.9.3",
+              "id": "parking_lot_core 0.9.4",
               "target": "parking_lot_core"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "1.13.1"
+        "edition": "2021",
+        "version": "1.16.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -11995,13 +12056,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "openssl 0.10.41": {
+    "openssl 0.10.42": {
       "name": "openssl",
-      "version": "0.10.41",
+      "version": "0.10.42",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/openssl/0.10.41/download",
-          "sha256": "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+          "url": "https://crates.io/api/v1/crates/openssl/0.10.42/download",
+          "sha256": "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
         }
       },
       "targets": [
@@ -12035,6 +12096,9 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": [
+          "default"
+        ],
         "deps": {
           "common": [
             {
@@ -12050,19 +12114,19 @@
               "target": "foreign_types"
             },
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
-              "id": "openssl 0.10.41",
+              "id": "openssl 0.10.42",
               "target": "build_script_build"
             },
             {
-              "id": "openssl-sys 0.9.75",
+              "id": "openssl-sys 0.9.77",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -12079,7 +12143,7 @@
           ],
           "selects": {}
         },
-        "version": "0.10.41"
+        "version": "0.10.42"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12088,7 +12152,7 @@
         "deps": {
           "common": [
             {
-              "id": "openssl-sys 0.9.75",
+              "id": "openssl-sys 0.9.77",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -12129,7 +12193,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -12137,7 +12201,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -12181,13 +12245,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "openssl-sys 0.9.75": {
+    "openssl-sys 0.9.77": {
       "name": "openssl-sys",
-      "version": "0.9.75",
+      "version": "0.9.77",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/openssl-sys/0.9.75/download",
-          "sha256": "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+          "url": "https://crates.io/api/v1/crates/openssl-sys/0.9.77/download",
+          "sha256": "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
         }
       },
       "targets": [
@@ -12224,18 +12288,18 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             },
             {
-              "id": "openssl-sys 0.9.75",
+              "id": "openssl-sys 0.9.77",
               "target": "build_script_main"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.9.75"
+        "version": "0.9.77"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12248,11 +12312,11 @@
               "target": "autocfg"
             },
             {
-              "id": "cc 1.0.73",
+              "id": "cc 1.0.74",
               "target": "cc"
             },
             {
-              "id": "pkg-config 0.3.25",
+              "id": "pkg-config 0.3.26",
               "target": "pkg_config"
             }
           ],
@@ -12269,13 +12333,13 @@
       },
       "license": "MIT"
     },
-    "os_str_bytes 6.3.0": {
+    "os_str_bytes 6.3.1": {
       "name": "os_str_bytes",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.3.0/download",
-          "sha256": "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.3.1/download",
+          "sha256": "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
         }
       },
       "targets": [
@@ -12301,9 +12365,42 @@
           "raw_os_str"
         ],
         "edition": "2021",
-        "version": "6.3.0"
+        "version": "6.3.1"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "overload 0.1.1": {
+      "name": "overload",
+      "version": "0.1.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/overload/0.1.1/download",
+          "sha256": "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "overload",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "overload",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.1.1"
+      },
+      "license": "MIT"
     },
     "p256 0.9.0": {
       "name": "p256",
@@ -12436,11 +12533,11 @@
         "deps": {
           "common": [
             {
-              "id": "lock_api 0.4.8",
+              "id": "lock_api 0.4.9",
               "target": "lock_api"
             },
             {
-              "id": "parking_lot_core 0.9.3",
+              "id": "parking_lot_core 0.9.4",
               "target": "parking_lot_core"
             }
           ],
@@ -12451,13 +12548,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "parking_lot_core 0.9.3": {
+    "parking_lot_core 0.9.4": {
       "name": "parking_lot_core",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.3/download",
-          "sha256": "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.4/download",
+          "sha256": "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
         }
       },
       "targets": [
@@ -12498,11 +12595,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "parking_lot_core 0.9.3",
+              "id": "parking_lot_core 0.9.4",
               "target": "build_script_build"
             },
             {
-              "id": "smallvec 1.9.0",
+              "id": "smallvec 1.10.0",
               "target": "smallvec"
             }
           ],
@@ -12515,20 +12612,20 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.36.1",
+                "id": "windows-sys 0.42.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.9.3"
+        "version": "0.9.4"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12568,7 +12665,7 @@
         "deps": {
           "common": [
             {
-              "id": "digest 0.10.3",
+              "id": "digest 0.10.5",
               "target": "digest"
             }
           ],
@@ -12752,7 +12849,7 @@
               "target": "peg_runtime"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -12890,20 +12987,20 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "percent-encoding 2.1.0": {
+    "percent-encoding 2.2.0": {
       "name": "percent-encoding",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/percent-encoding/2.1.0/download",
-          "sha256": "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+          "url": "https://crates.io/api/v1/crates/percent-encoding/2.2.0/download",
+          "sha256": "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
         }
       },
       "targets": [
         {
           "Library": {
             "crate_name": "percent_encoding",
-            "crate_root": "lib.rs",
+            "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -12918,10 +13015,14 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2015",
-        "version": "2.1.0"
+        "crate_features": [
+          "alloc",
+          "default"
+        ],
+        "edition": "2018",
+        "version": "2.2.0"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "pin-project-lite 0.2.9": {
       "name": "pin-project-lite",
@@ -13177,7 +13278,7 @@
               "target": "pkcs5"
             },
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             },
             {
@@ -13196,13 +13297,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "pkg-config 0.3.25": {
+    "pkg-config 0.3.26": {
       "name": "pkg-config",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pkg-config/0.3.25/download",
-          "sha256": "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+          "url": "https://crates.io/api/v1/crates/pkg-config/0.3.26/download",
+          "sha256": "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
         }
       },
       "targets": [
@@ -13225,17 +13326,17 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "polling 2.3.0": {
+    "polling 2.4.0": {
       "name": "polling",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/polling/2.3.0/download",
-          "sha256": "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+          "url": "https://crates.io/api/v1/crates/polling/2.4.0/download",
+          "sha256": "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
         }
       },
       "targets": [
@@ -13284,14 +13385,14 @@
               "target": "log"
             },
             {
-              "id": "polling 2.3.0",
+              "id": "polling 2.4.0",
               "target": "build_script_build"
             }
           ],
           "selects": {
             "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
@@ -13308,7 +13409,7 @@
           }
         },
         "edition": "2018",
-        "version": "2.3.0"
+        "version": "2.4.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -13410,7 +13511,7 @@
               "target": "float_cmp"
             },
             {
-              "id": "itertools 0.10.3",
+              "id": "itertools 0.10.5",
               "target": "itertools"
             },
             {
@@ -13564,7 +13665,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -13572,7 +13673,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -13653,7 +13754,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -13682,13 +13783,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.43": {
+    "proc-macro2 1.0.47": {
       "name": "proc-macro2",
-      "version": "1.0.43",
+      "version": "1.0.47",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.43/download",
-          "sha256": "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.47/download",
+          "sha256": "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
         }
       },
       "targets": [
@@ -13729,18 +13830,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.3",
+              "id": "unicode-ident 1.0.5",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.43"
+        "version": "1.0.47"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -13961,7 +14062,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -14044,7 +14145,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ]
@@ -14099,14 +14200,14 @@
               "target": "rand_chacha"
             },
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             }
           ],
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ]
@@ -14204,7 +14305,7 @@
               "target": "ppv_lite86"
             },
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             }
           ],
@@ -14262,13 +14363,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "rand_core 0.6.3": {
+    "rand_core 0.6.4": {
       "name": "rand_core",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rand_core/0.6.3/download",
-          "sha256": "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+          "url": "https://crates.io/api/v1/crates/rand_core/0.6.4/download",
+          "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
         }
       },
       "targets": [
@@ -14298,14 +14399,14 @@
         "deps": {
           "common": [
             {
-              "id": "getrandom 0.2.7",
+              "id": "getrandom 0.2.8",
               "target": "getrandom"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.6.3"
+        "version": "0.6.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -14382,7 +14483,7 @@
         "deps": {
           "common": [
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             }
           ],
@@ -14485,7 +14586,7 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 0.7.18",
+              "id": "aho-corasick 0.7.19",
               "target": "aho_corasick"
             },
             {
@@ -14592,13 +14693,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "reqwest 0.11.11": {
+    "reqwest 0.11.12": {
       "name": "reqwest",
-      "version": "0.11.11",
+      "version": "0.11.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/reqwest/0.11.11/download",
-          "sha256": "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+          "url": "https://crates.io/api/v1/crates/reqwest/0.11.12/download",
+          "sha256": "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
         }
       },
       "targets": [
@@ -14632,7 +14733,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.13.0",
+              "id": "base64 0.13.1",
               "target": "base64"
             },
             {
@@ -14644,7 +14745,7 @@
               "target": "http"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
@@ -14656,7 +14757,7 @@
               "target": "tower_service"
             },
             {
-              "id": "url 2.2.2",
+              "id": "url 2.3.1",
               "target": "url"
             }
           ],
@@ -14667,15 +14768,15 @@
                 "target": "encoding_rs"
               },
               {
-                "id": "futures-core 0.3.24",
+                "id": "futures-core 0.3.25",
                 "target": "futures_core"
               },
               {
-                "id": "futures-util 0.3.24",
+                "id": "futures-util 0.3.25",
                 "target": "futures_util"
               },
               {
-                "id": "h2 0.3.14",
+                "id": "h2 0.3.15",
                 "target": "h2"
               },
               {
@@ -14683,7 +14784,7 @@
                 "target": "http_body"
               },
               {
-                "id": "hyper 0.14.20",
+                "id": "hyper 0.14.21",
                 "target": "hyper"
               },
               {
@@ -14693,10 +14794,6 @@
               {
                 "id": "ipnet 2.5.0",
                 "target": "ipnet"
-              },
-              {
-                "id": "lazy_static 1.4.0",
-                "target": "lazy_static"
               },
               {
                 "id": "log 0.4.17",
@@ -14712,7 +14809,11 @@
                 "alias": "native_tls_crate"
               },
               {
-                "id": "percent-encoding 2.1.0",
+                "id": "once_cell 1.16.0",
+                "target": "once_cell"
+              },
+              {
+                "id": "percent-encoding 2.2.0",
                 "target": "percent_encoding"
               },
               {
@@ -14720,7 +14821,7 @@
                 "target": "pin_project_lite"
               },
               {
-                "id": "tokio 1.20.1",
+                "id": "tokio 1.21.2",
                 "target": "tokio"
               },
               {
@@ -14730,23 +14831,23 @@
             ],
             "cfg(target_arch = \"wasm32\")": [
               {
-                "id": "js-sys 0.3.59",
+                "id": "js-sys 0.3.60",
                 "target": "js_sys"
               },
               {
-                "id": "serde_json 1.0.85",
+                "id": "serde_json 1.0.87",
                 "target": "serde_json"
               },
               {
-                "id": "wasm-bindgen 0.2.82",
+                "id": "wasm-bindgen 0.2.83",
                 "target": "wasm_bindgen"
               },
               {
-                "id": "wasm-bindgen-futures 0.4.32",
+                "id": "wasm-bindgen-futures 0.4.33",
                 "target": "wasm_bindgen_futures"
               },
               {
-                "id": "web-sys 0.3.59",
+                "id": "web-sys 0.3.60",
                 "target": "web_sys"
               }
             ],
@@ -14759,7 +14860,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.11.11"
+        "version": "0.11.12"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -14794,18 +14895,18 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.85",
+              "id": "serde_json 1.0.87",
               "target": "serde_json"
             }
           ],
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
@@ -15220,7 +15321,7 @@
               "target": "salsa20"
             },
             {
-              "id": "sha2 0.10.3",
+              "id": "sha2 0.10.6",
               "target": "sha2"
             }
           ],
@@ -15266,7 +15367,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -15274,7 +15375,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -15320,7 +15421,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -15328,7 +15429,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -15386,7 +15487,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             },
             {
@@ -15440,7 +15541,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             }
           ],
@@ -15451,13 +15552,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "semver 1.0.13": {
+    "semver 1.0.14": {
       "name": "semver",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/semver/1.0.13/download",
-          "sha256": "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+          "url": "https://crates.io/api/v1/crates/semver/1.0.14/download",
+          "sha256": "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
         }
       },
       "targets": [
@@ -15498,14 +15599,14 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.13",
+              "id": "semver 1.0.14",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.13"
+        "version": "1.0.14"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -15547,13 +15648,13 @@
       },
       "license": "MIT"
     },
-    "serde 1.0.144": {
+    "serde 1.0.147": {
       "name": "serde",
-      "version": "1.0.144",
+      "version": "1.0.147",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.144/download",
-          "sha256": "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.147/download",
+          "sha256": "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
         }
       },
       "targets": [
@@ -15597,7 +15698,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "build_script_build"
             }
           ],
@@ -15607,13 +15708,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.144",
+              "id": "serde_derive 1.0.147",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.144"
+        "version": "1.0.147"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -15622,13 +15723,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.144": {
+    "serde_derive 1.0.147": {
       "name": "serde_derive",
-      "version": "1.0.144",
+      "version": "1.0.147",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.144/download",
-          "sha256": "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.147/download",
+          "sha256": "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
         }
       },
       "targets": [
@@ -15668,7 +15769,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -15676,18 +15777,18 @@
               "target": "quote"
             },
             {
-              "id": "serde_derive 1.0.144",
+              "id": "serde_derive 1.0.147",
               "target": "build_script_build"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.144"
+        "version": "1.0.147"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -15696,13 +15797,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.85": {
+    "serde_json 1.0.87": {
       "name": "serde_json",
-      "version": "1.0.85",
+      "version": "1.0.87",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_json/1.0.85/download",
-          "sha256": "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+          "url": "https://crates.io/api/v1/crates/serde_json/1.0.87/download",
+          "sha256": "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
         }
       },
       "targets": [
@@ -15743,7 +15844,7 @@
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.3",
+              "id": "itoa 1.0.4",
               "target": "itoa"
             },
             {
@@ -15751,18 +15852,18 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.85",
+              "id": "serde_json 1.0.87",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.85"
+        "version": "1.0.87"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -15771,13 +15872,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_test 1.0.144": {
+    "serde_test 1.0.147": {
       "name": "serde_test",
-      "version": "1.0.144",
+      "version": "1.0.147",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_test/1.0.144/download",
-          "sha256": "6c7f3621491f256177206a7c2152c17f322c0d0b30af05359088172437d29e25"
+          "url": "https://crates.io/api/v1/crates/serde_test/1.0.147/download",
+          "sha256": "641666500e4e6fba7b91b73651a375cb53579468ab3c38389289b802797cad94"
         }
       },
       "targets": [
@@ -15814,18 +15915,18 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "serde_test 1.0.144",
+              "id": "serde_test 1.0.147",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.144"
+        "version": "1.0.147"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -15865,15 +15966,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -15915,11 +16016,11 @@
         "deps": {
           "common": [
             {
-              "id": "form_urlencoded 1.0.1",
+              "id": "form_urlencoded 1.1.0",
               "target": "form_urlencoded"
             },
             {
-              "id": "itoa 1.0.3",
+              "id": "itoa 1.0.4",
               "target": "itoa"
             },
             {
@@ -15927,7 +16028,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             }
           ],
@@ -15938,13 +16039,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "sha2 0.10.3": {
+    "sha2 0.10.6": {
       "name": "sha2",
-      "version": "0.10.3",
+      "version": "0.10.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sha2/0.10.3/download",
-          "sha256": "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
+          "url": "https://crates.io/api/v1/crates/sha2/0.10.6/download",
+          "sha256": "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
         }
       },
       "targets": [
@@ -15977,21 +16078,21 @@
               "target": "cfg_if"
             },
             {
-              "id": "digest 0.10.3",
+              "id": "digest 0.10.5",
               "target": "digest"
             }
           ],
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
               {
-                "id": "cpufeatures 0.2.4",
+                "id": "cpufeatures 0.2.5",
                 "target": "cpufeatures"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.10.3"
+        "version": "0.10.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -16048,7 +16149,7 @@
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
               {
-                "id": "cpufeatures 0.2.4",
+                "id": "cpufeatures 0.2.5",
                 "target": "cpufeatures"
               }
             ]
@@ -16059,13 +16160,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "sha3 0.10.2": {
+    "sha3 0.10.6": {
       "name": "sha3",
-      "version": "0.10.2",
+      "version": "0.10.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sha3/0.10.2/download",
-          "sha256": "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
+          "url": "https://crates.io/api/v1/crates/sha3/0.10.6/download",
+          "sha256": "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
         }
       },
       "targets": [
@@ -16094,7 +16195,7 @@
         "deps": {
           "common": [
             {
-              "id": "digest 0.10.3",
+              "id": "digest 0.10.5",
               "target": "digest"
             },
             {
@@ -16105,7 +16206,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.2"
+        "version": "0.10.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -16293,7 +16394,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             },
             {
@@ -16348,7 +16449,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             }
           ],
@@ -16402,7 +16503,7 @@
               "target": "digest"
             },
             {
-              "id": "rand_core 0.6.3",
+              "id": "rand_core 0.6.4",
               "target": "rand_core"
             }
           ],
@@ -16485,13 +16586,13 @@
       },
       "license": "MIT"
     },
-    "smallvec 1.9.0": {
+    "smallvec 1.10.0": {
       "name": "smallvec",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/smallvec/1.9.0/download",
-          "sha256": "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+          "url": "https://crates.io/api/v1/crates/smallvec/1.10.0/download",
+          "sha256": "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
         }
       },
       "targets": [
@@ -16514,7 +16615,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.9.0"
+        "version": "1.10.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -16561,11 +16662,11 @@
               "target": "async_fs"
             },
             {
-              "id": "async-io 1.8.0",
+              "id": "async-io 1.10.0",
               "target": "async_io"
             },
             {
-              "id": "async-lock 2.5.0",
+              "id": "async-lock 2.6.0",
               "target": "async_lock"
             },
             {
@@ -16585,7 +16686,7 @@
               "target": "futures_lite"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             }
           ],
@@ -16632,7 +16733,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
@@ -16872,9 +16973,20 @@
         ],
         "crate_features": [
           "default",
-          "std"
+          "derive",
+          "std",
+          "strum_macros"
         ],
         "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "strum_macros 0.24.3",
+              "target": "strum_macros"
+            }
+          ],
+          "selects": {}
+        },
         "version": "0.24.1"
       },
       "license": "MIT"
@@ -16914,7 +17026,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -16922,7 +17034,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -16979,13 +17091,13 @@
       },
       "license": "BSD-3-Clause"
     },
-    "syn 1.0.99": {
+    "syn 1.0.103": {
       "name": "syn",
-      "version": "1.0.99",
+      "version": "1.0.103",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.99/download",
-          "sha256": "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.103/download",
+          "sha256": "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
         }
       },
       "targets": [
@@ -17035,7 +17147,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -17043,18 +17155,18 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.3",
+              "id": "unicode-ident 1.0.5",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.99"
+        "version": "1.0.103"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -17098,7 +17210,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -17106,11 +17218,11 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             },
             {
-              "id": "unicode-xid 0.2.3",
+              "id": "unicode-xid 0.2.4",
               "target": "unicode_xid"
             }
           ],
@@ -17152,7 +17264,7 @@
         "deps": {
           "common": [
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             },
             {
@@ -17207,7 +17319,7 @@
         "deps": {
           "common": [
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             },
             {
@@ -17253,7 +17365,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -17261,7 +17373,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -17389,7 +17501,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
@@ -17489,7 +17601,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ],
@@ -17570,7 +17682,7 @@
         "deps": {
           "common": [
             {
-              "id": "unicode-width 0.1.9",
+              "id": "unicode-width 0.1.10",
               "target": "unicode_width"
             }
           ],
@@ -17612,7 +17724,7 @@
         "deps": {
           "common": [
             {
-              "id": "unicode-width 0.1.9",
+              "id": "unicode-width 0.1.10",
               "target": "unicode_width"
             }
           ],
@@ -17623,13 +17735,13 @@
       },
       "license": "MIT"
     },
-    "textwrap 0.15.0": {
+    "textwrap 0.16.0": {
       "name": "textwrap",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/textwrap/0.15.0/download",
-          "sha256": "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+          "url": "https://crates.io/api/v1/crates/textwrap/0.16.0/download",
+          "sha256": "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
         }
       },
       "targets": [
@@ -17651,18 +17763,18 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2018",
-        "version": "0.15.0"
+        "edition": "2021",
+        "version": "0.16.0"
       },
       "license": "MIT"
     },
-    "thiserror 1.0.33": {
+    "thiserror 1.0.37": {
       "name": "thiserror",
-      "version": "1.0.33",
+      "version": "1.0.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror/1.0.33/download",
-          "sha256": "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
+          "url": "https://crates.io/api/v1/crates/thiserror/1.0.37/download",
+          "sha256": "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
         }
       },
       "targets": [
@@ -17677,6 +17789,18 @@
               "exclude": []
             }
           }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
         }
       ],
       "library_target_name": "thiserror",
@@ -17684,27 +17808,41 @@
         "compile_data_glob": [
           "**"
         ],
+        "deps": {
+          "common": [
+            {
+              "id": "thiserror 1.0.37",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.33",
+              "id": "thiserror-impl 1.0.37",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.33"
+        "version": "1.0.37"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
       },
       "license": "MIT OR Apache-2.0"
     },
-    "thiserror-impl 1.0.33": {
+    "thiserror-impl 1.0.37": {
       "name": "thiserror-impl",
-      "version": "1.0.33",
+      "version": "1.0.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.33/download",
-          "sha256": "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
+          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.37/download",
+          "sha256": "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
         }
       },
       "targets": [
@@ -17729,7 +17867,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -17737,14 +17875,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.33"
+        "version": "1.0.37"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -17779,7 +17917,7 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             }
           ],
@@ -17790,13 +17928,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "time 0.3.14": {
+    "time 0.3.16": {
       "name": "time",
-      "version": "0.3.14",
+      "version": "0.3.16",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time/0.3.14/download",
-          "sha256": "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+          "url": "https://crates.io/api/v1/crates/time/0.3.16/download",
+          "sha256": "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
         }
       },
       "targets": [
@@ -17822,23 +17960,29 @@
           "alloc",
           "default",
           "formatting",
-          "itoa",
           "macros",
           "parsing",
-          "std",
-          "time-macros"
+          "std"
         ],
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.3",
+              "id": "itoa 1.0.4",
               "target": "itoa"
+            },
+            {
+              "id": "serde 1.0.147",
+              "target": "serde"
+            },
+            {
+              "id": "time-core 0.1.0",
+              "target": "time_core"
             }
           ],
           "selects": {
             "cfg(target_family = \"unix\")": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               },
               {
@@ -17852,23 +17996,56 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "time-macros 0.2.4",
+              "id": "time-macros 0.2.5",
               "target": "time_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.14"
+        "version": "0.3.16"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "time-macros 0.2.4": {
-      "name": "time-macros",
-      "version": "0.2.4",
+    "time-core 0.1.0": {
+      "name": "time-core",
+      "version": "0.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time-macros/0.2.4/download",
-          "sha256": "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+          "url": "https://crates.io/api/v1/crates/time-core/0.1.0/download",
+          "sha256": "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "time_core",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "time_core",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "time-macros 0.2.5": {
+      "name": "time-macros",
+      "version": "0.2.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/time-macros/0.2.5/download",
+          "sha256": "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
         }
       },
       "targets": [
@@ -17890,8 +18067,21 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2018",
-        "version": "0.2.4"
+        "crate_features": [
+          "formatting",
+          "parsing"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "time-core 0.1.0",
+              "target": "time_core"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.5"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -17929,7 +18119,7 @@
         "deps": {
           "common": [
             {
-              "id": "ascii 1.0.0",
+              "id": "ascii 1.1.0",
               "target": "ascii"
             },
             {
@@ -17941,11 +18131,11 @@
               "target": "log"
             },
             {
-              "id": "time 0.3.14",
+              "id": "time 0.3.16",
               "target": "time"
             },
             {
-              "id": "url 2.2.2",
+              "id": "url 2.3.1",
               "target": "url"
             }
           ],
@@ -18036,13 +18226,13 @@
       },
       "license": "MIT OR Apache-2.0 OR Zlib"
     },
-    "tokio 1.20.1": {
+    "tokio 1.21.2": {
       "name": "tokio",
-      "version": "1.20.1",
+      "version": "1.21.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.20.1/download",
-          "sha256": "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+          "url": "https://crates.io/api/v1/crates/tokio/1.21.2/download",
+          "sha256": "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
         }
       },
       "targets": [
@@ -18089,7 +18279,6 @@
           "mio",
           "net",
           "num_cpus",
-          "once_cell",
           "parking_lot",
           "process",
           "rt",
@@ -18113,16 +18302,12 @@
               "target": "memchr"
             },
             {
-              "id": "mio 0.8.4",
+              "id": "mio 0.8.5",
               "target": "mio"
             },
             {
               "id": "num_cpus 1.13.1",
               "target": "num_cpus"
-            },
-            {
-              "id": "once_cell 1.13.1",
-              "target": "once_cell"
             },
             {
               "id": "parking_lot 0.12.1",
@@ -18133,18 +18318,20 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "socket2 0.4.7",
-              "target": "socket2"
-            },
-            {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "build_script_build"
             }
           ],
           "selects": {
+            "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))": [
+              {
+                "id": "socket2 0.4.7",
+                "target": "socket2"
+              }
+            ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               },
               {
@@ -18170,7 +18357,7 @@
           ],
           "selects": {}
         },
-        "version": "1.20.1"
+        "version": "1.21.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -18219,7 +18406,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -18227,7 +18414,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -18273,7 +18460,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             }
           ],
@@ -18284,13 +18471,13 @@
       },
       "license": "MIT"
     },
-    "tokio-util 0.7.3": {
+    "tokio-util 0.7.4": {
       "name": "tokio-util",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-util/0.7.3/download",
-          "sha256": "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+          "url": "https://crates.io/api/v1/crates/tokio-util/0.7.4/download",
+          "sha256": "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
         }
       },
       "targets": [
@@ -18324,11 +18511,11 @@
               "target": "bytes"
             },
             {
-              "id": "futures-core 0.3.24",
+              "id": "futures-core 0.3.25",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.24",
+              "id": "futures-sink 0.3.25",
               "target": "futures_sink"
             },
             {
@@ -18336,18 +18523,18 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.20.1",
+              "id": "tokio 1.21.2",
               "target": "tokio"
             },
             {
-              "id": "tracing 0.1.36",
+              "id": "tracing 0.1.37",
               "target": "tracing"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.7.3"
+        "version": "0.7.4"
       },
       "license": "MIT"
     },
@@ -18385,7 +18572,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.144",
+              "id": "serde 1.0.147",
               "target": "serde"
             }
           ],
@@ -18429,13 +18616,13 @@
       },
       "license": "MIT"
     },
-    "tracing 0.1.36": {
+    "tracing 0.1.37": {
       "name": "tracing",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing/0.1.36/download",
-          "sha256": "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+          "url": "https://crates.io/api/v1/crates/tracing/0.1.37/download",
+          "sha256": "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
         }
       },
       "targets": [
@@ -18474,7 +18661,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tracing-core 0.1.29",
+              "id": "tracing-core 0.1.30",
               "target": "tracing_core"
             }
           ],
@@ -18484,23 +18671,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tracing-attributes 0.1.22",
+              "id": "tracing-attributes 0.1.23",
               "target": "tracing_attributes"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.36"
+        "version": "0.1.37"
       },
       "license": "MIT"
     },
-    "tracing-attributes 0.1.22": {
+    "tracing-attributes 0.1.23": {
       "name": "tracing-attributes",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.22/download",
-          "sha256": "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.23/download",
+          "sha256": "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
         }
       },
       "targets": [
@@ -18525,7 +18712,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -18533,24 +18720,24 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.22"
+        "version": "0.1.23"
       },
       "license": "MIT"
     },
-    "tracing-core 0.1.29": {
+    "tracing-core 0.1.30": {
       "name": "tracing-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.29/download",
-          "sha256": "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.30/download",
+          "sha256": "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
         }
       },
       "targets": [
@@ -18581,7 +18768,7 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             }
           ],
@@ -18595,7 +18782,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.1.29"
+        "version": "0.1.30"
       },
       "license": "MIT"
     },
@@ -18642,7 +18829,7 @@
               "target": "log"
             },
             {
-              "id": "tracing-core 0.1.29",
+              "id": "tracing-core 0.1.30",
               "target": "tracing_core"
             }
           ],
@@ -18653,13 +18840,13 @@
       },
       "license": "MIT"
     },
-    "tracing-subscriber 0.3.15": {
+    "tracing-subscriber 0.3.16": {
       "name": "tracing-subscriber",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.15/download",
-          "sha256": "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.16/download",
+          "sha256": "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
         }
       },
       "targets": [
@@ -18684,9 +18871,9 @@
         "crate_features": [
           "alloc",
           "ansi",
-          "ansi_term",
           "default",
           "fmt",
+          "nu-ansi-term",
           "registry",
           "sharded-slab",
           "smallvec",
@@ -18697,15 +18884,15 @@
         "deps": {
           "common": [
             {
-              "id": "ansi_term 0.12.1",
-              "target": "ansi_term"
+              "id": "nu-ansi-term 0.46.0",
+              "target": "nu_ansi_term"
             },
             {
               "id": "sharded-slab 0.1.4",
               "target": "sharded_slab"
             },
             {
-              "id": "smallvec 1.9.0",
+              "id": "smallvec 1.10.0",
               "target": "smallvec"
             },
             {
@@ -18713,7 +18900,7 @@
               "target": "thread_local"
             },
             {
-              "id": "tracing-core 0.1.29",
+              "id": "tracing-core 0.1.30",
               "target": "tracing_core"
             },
             {
@@ -18724,7 +18911,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.15"
+        "version": "0.3.16"
       },
       "license": "MIT"
     },
@@ -18792,7 +18979,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -18800,7 +18987,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             }
           ],
@@ -18908,13 +19095,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "unicode-ident 1.0.3": {
+    "unicode-ident 1.0.5": {
       "name": "unicode-ident",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.3/download",
-          "sha256": "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.5/download",
+          "sha256": "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
         }
       },
       "targets": [
@@ -18937,17 +19124,17 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.3"
+        "version": "1.0.5"
       },
       "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
     },
-    "unicode-normalization 0.1.21": {
+    "unicode-normalization 0.1.22": {
       "name": "unicode-normalization",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-normalization/0.1.21/download",
-          "sha256": "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+          "url": "https://crates.io/api/v1/crates/unicode-normalization/0.1.22/download",
+          "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
         }
       },
       "targets": [
@@ -18983,17 +19170,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.21"
+        "version": "0.1.22"
       },
       "license": "MIT/Apache-2.0"
     },
-    "unicode-segmentation 1.9.0": {
+    "unicode-segmentation 1.10.0": {
       "name": "unicode-segmentation",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-segmentation/1.9.0/download",
-          "sha256": "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+          "url": "https://crates.io/api/v1/crates/unicode-segmentation/1.10.0/download",
+          "sha256": "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
         }
       },
       "targets": [
@@ -19016,17 +19203,17 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.9.0"
+        "version": "1.10.0"
       },
       "license": "MIT/Apache-2.0"
     },
-    "unicode-width 0.1.9": {
+    "unicode-width 0.1.10": {
       "name": "unicode-width",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-width/0.1.9/download",
-          "sha256": "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+          "url": "https://crates.io/api/v1/crates/unicode-width/0.1.10/download",
+          "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
         }
       },
       "targets": [
@@ -19052,17 +19239,17 @@
           "default"
         ],
         "edition": "2015",
-        "version": "0.1.9"
+        "version": "0.1.10"
       },
       "license": "MIT/Apache-2.0"
     },
-    "unicode-xid 0.2.3": {
+    "unicode-xid 0.2.4": {
       "name": "unicode-xid",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-xid/0.2.3/download",
-          "sha256": "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+          "url": "https://crates.io/api/v1/crates/unicode-xid/0.2.4/download",
+          "sha256": "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
         }
       },
       "targets": [
@@ -19088,17 +19275,17 @@
           "default"
         ],
         "edition": "2015",
-        "version": "0.2.3"
+        "version": "0.2.4"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "url 2.2.2": {
+    "url 2.3.1": {
       "name": "url",
-      "version": "2.2.2",
+      "version": "2.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/url/2.2.2/download",
-          "sha256": "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+          "url": "https://crates.io/api/v1/crates/url/2.3.1/download",
+          "sha256": "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
         }
       },
       "targets": [
@@ -19120,39 +19307,38 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": [
+          "default"
+        ],
         "deps": {
           "common": [
             {
-              "id": "form_urlencoded 1.0.1",
+              "id": "form_urlencoded 1.1.0",
               "target": "form_urlencoded"
             },
             {
-              "id": "idna 0.2.3",
+              "id": "idna 0.3.0",
               "target": "idna"
             },
             {
-              "id": "matches 0.1.9",
-              "target": "matches"
-            },
-            {
-              "id": "percent-encoding 2.1.0",
+              "id": "percent-encoding 2.2.0",
               "target": "percent_encoding"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.2.2"
+        "version": "2.3.1"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
-    "uuid 1.1.2": {
+    "uuid 1.2.1": {
       "name": "uuid",
-      "version": "1.1.2",
+      "version": "1.2.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/uuid/1.1.2/download",
-          "sha256": "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+          "url": "https://crates.io/api/v1/crates/uuid/1.2.1/download",
+          "sha256": "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
         }
       },
       "targets": [
@@ -19175,7 +19361,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.1.2"
+        "version": "1.2.1"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -19410,7 +19596,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.132",
+                "id": "libc 0.2.137",
                 "target": "libc"
               }
             ]
@@ -19627,13 +19813,13 @@
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
-    "wasm-bindgen 0.2.82": {
+    "wasm-bindgen 0.2.83": {
       "name": "wasm-bindgen",
-      "version": "0.2.82",
+      "version": "0.2.83",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen/0.2.82/download",
-          "sha256": "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen/0.2.83/download",
+          "sha256": "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
         }
       },
       "targets": [
@@ -19679,7 +19865,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "wasm-bindgen 0.2.82",
+              "id": "wasm-bindgen 0.2.83",
               "target": "build_script_build"
             }
           ],
@@ -19689,13 +19875,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasm-bindgen-macro 0.2.82",
+              "id": "wasm-bindgen-macro 0.2.83",
               "target": "wasm_bindgen_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.2.82"
+        "version": "0.2.83"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -19704,13 +19890,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-backend 0.2.82": {
+    "wasm-bindgen-backend 0.2.83": {
       "name": "wasm-bindgen-backend",
-      "version": "0.2.82",
+      "version": "0.2.83",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.82/download",
-          "sha256": "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.83/download",
+          "sha256": "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
         }
       },
       "targets": [
@@ -19738,7 +19924,7 @@
         "deps": {
           "common": [
             {
-              "id": "bumpalo 3.11.0",
+              "id": "bumpalo 3.11.1",
               "target": "bumpalo"
             },
             {
@@ -19746,11 +19932,11 @@
               "target": "log"
             },
             {
-              "id": "once_cell 1.13.1",
+              "id": "once_cell 1.16.0",
               "target": "once_cell"
             },
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -19758,28 +19944,28 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.82",
+              "id": "wasm-bindgen-shared 0.2.83",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.82"
+        "version": "0.2.83"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-futures 0.4.32": {
+    "wasm-bindgen-futures 0.4.33": {
       "name": "wasm-bindgen-futures",
-      "version": "0.4.32",
+      "version": "0.4.33",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-futures/0.4.32/download",
-          "sha256": "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-futures/0.4.33/download",
+          "sha256": "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
         }
       },
       "targets": [
@@ -19808,35 +19994,35 @@
               "target": "cfg_if"
             },
             {
-              "id": "js-sys 0.3.59",
+              "id": "js-sys 0.3.60",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.82",
+              "id": "wasm-bindgen 0.2.83",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {
             "cfg(target_feature = \"atomics\")": [
               {
-                "id": "web-sys 0.3.59",
+                "id": "web-sys 0.3.60",
                 "target": "web_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.4.32"
+        "version": "0.4.33"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-macro 0.2.82": {
+    "wasm-bindgen-macro 0.2.83": {
       "name": "wasm-bindgen-macro",
-      "version": "0.2.82",
+      "version": "0.2.83",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.82/download",
-          "sha256": "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.83/download",
+          "sha256": "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
         }
       },
       "targets": [
@@ -19868,24 +20054,24 @@
               "target": "quote"
             },
             {
-              "id": "wasm-bindgen-macro-support 0.2.82",
+              "id": "wasm-bindgen-macro-support 0.2.83",
               "target": "wasm_bindgen_macro_support"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.82"
+        "version": "0.2.83"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-macro-support 0.2.82": {
+    "wasm-bindgen-macro-support 0.2.83": {
       "name": "wasm-bindgen-macro-support",
-      "version": "0.2.82",
+      "version": "0.2.83",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.82/download",
-          "sha256": "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.83/download",
+          "sha256": "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
         }
       },
       "targets": [
@@ -19913,7 +20099,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -19921,32 +20107,32 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-backend 0.2.82",
+              "id": "wasm-bindgen-backend 0.2.83",
               "target": "wasm_bindgen_backend"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.82",
+              "id": "wasm-bindgen-shared 0.2.83",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.82"
+        "version": "0.2.83"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-shared 0.2.82": {
+    "wasm-bindgen-shared 0.2.83": {
       "name": "wasm-bindgen-shared",
-      "version": "0.2.82",
+      "version": "0.2.83",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.82/download",
-          "sha256": "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.83/download",
+          "sha256": "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
         }
       },
       "targets": [
@@ -19983,14 +20169,14 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen-shared 0.2.82",
+              "id": "wasm-bindgen-shared 0.2.83",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.82"
+        "version": "0.2.83"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -20000,13 +20186,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "web-sys 0.3.59": {
+    "web-sys 0.3.60": {
       "name": "web-sys",
-      "version": "0.3.59",
+      "version": "0.3.60",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/web-sys/0.3.59/download",
-          "sha256": "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+          "url": "https://crates.io/api/v1/crates/web-sys/0.3.60/download",
+          "sha256": "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
         }
       },
       "targets": [
@@ -20050,18 +20236,18 @@
         "deps": {
           "common": [
             {
-              "id": "js-sys 0.3.59",
+              "id": "js-sys 0.3.60",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.82",
+              "id": "wasm-bindgen 0.2.83",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.59"
+        "version": "0.3.60"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -20127,7 +20313,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.73",
+              "id": "cc 1.0.74",
               "target": "cc"
             }
           ],
@@ -20171,14 +20357,14 @@
               "target": "either"
             },
             {
-              "id": "libc 0.2.132",
+              "id": "libc 0.2.137",
               "target": "libc"
             }
           ],
           "selects": {
             "cfg(windows)": [
               {
-                "id": "once_cell 1.13.1",
+                "id": "once_cell 1.16.0",
                 "target": "once_cell"
               }
             ]
@@ -20230,6 +20416,8 @@
           "**"
         ],
         "crate_features": [
+          "accctrl",
+          "aclapi",
           "consoleapi",
           "errhandlingapi",
           "fileapi",
@@ -20481,22 +20669,13 @@
         "crate_features": [
           "Win32",
           "Win32_Foundation",
-          "Win32_Networking",
-          "Win32_Networking_WinSock",
           "Win32_Security",
           "Win32_Security_Authentication",
           "Win32_Security_Authentication_Identity",
           "Win32_Security_Credentials",
           "Win32_Security_Cryptography",
-          "Win32_Storage",
-          "Win32_Storage_FileSystem",
           "Win32_System",
-          "Win32_System_IO",
-          "Win32_System_LibraryLoader",
           "Win32_System_Memory",
-          "Win32_System_Pipes",
-          "Win32_System_SystemServices",
-          "Win32_System_WindowsProgramming",
           "default"
         ],
         "deps": {
@@ -20569,6 +20748,191 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows-sys 0.42.0": {
+      "name": "windows-sys",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows-sys/0.42.0/download",
+          "sha256": "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "Win32",
+          "Win32_Foundation",
+          "Win32_Networking",
+          "Win32_Networking_WinSock",
+          "Win32_Security",
+          "Win32_Storage",
+          "Win32_Storage_FileSystem",
+          "Win32_System",
+          "Win32_System_IO",
+          "Win32_System_LibraryLoader",
+          "Win32_System_Pipes",
+          "Win32_System_SystemServices",
+          "Win32_System_WindowsProgramming",
+          "default"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-gnullvm": [
+              {
+                "id": "windows_aarch64_gnullvm 0.42.0",
+                "target": "windows_aarch64_gnullvm"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "windows_aarch64_msvc 0.42.0",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "aarch64-uwp-windows-msvc": [
+              {
+                "id": "windows_aarch64_msvc 0.42.0",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "i686-pc-windows-gnu": [
+              {
+                "id": "windows_i686_gnu 0.42.0",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "windows_i686_msvc 0.42.0",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "i686-uwp-windows-gnu": [
+              {
+                "id": "windows_i686_gnu 0.42.0",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "i686-uwp-windows-msvc": [
+              {
+                "id": "windows_i686_msvc 0.42.0",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "x86_64-pc-windows-gnu": [
+              {
+                "id": "windows_x86_64_gnu 0.42.0",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "x86_64-pc-windows-gnullvm": [
+              {
+                "id": "windows_x86_64_gnullvm 0.42.0",
+                "target": "windows_x86_64_gnullvm"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "windows_x86_64_msvc 0.42.0",
+                "target": "windows_x86_64_msvc"
+              }
+            ],
+            "x86_64-uwp-windows-gnu": [
+              {
+                "id": "windows_x86_64_gnu 0.42.0",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "x86_64-uwp-windows-msvc": [
+              {
+                "id": "windows_x86_64_msvc 0.42.0",
+                "target": "windows_x86_64_msvc"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.42.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_aarch64_gnullvm 0.42.0": {
+      "name": "windows_aarch64_gnullvm",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.42.0/download",
+          "sha256": "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_gnullvm 0.42.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_aarch64_msvc 0.36.1": {
       "name": "windows_aarch64_msvc",
       "version": "0.36.1",
@@ -20620,6 +20984,65 @@
         },
         "edition": "2018",
         "version": "0.36.1"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_aarch64_msvc 0.42.0": {
+      "name": "windows_aarch64_msvc",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.42.0/download",
+          "sha256": "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_msvc 0.42.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -20687,6 +21110,65 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_i686_gnu 0.42.0": {
+      "name": "windows_i686_gnu",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.42.0/download",
+          "sha256": "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_gnu 0.42.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_i686_msvc 0.36.1": {
       "name": "windows_i686_msvc",
       "version": "0.36.1",
@@ -20738,6 +21220,65 @@
         },
         "edition": "2018",
         "version": "0.36.1"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_i686_msvc 0.42.0": {
+      "name": "windows_i686_msvc",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.42.0/download",
+          "sha256": "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_msvc 0.42.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -20805,6 +21346,124 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_x86_64_gnu 0.42.0": {
+      "name": "windows_x86_64_gnu",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.42.0/download",
+          "sha256": "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnu 0.42.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_gnullvm 0.42.0": {
+      "name": "windows_x86_64_gnullvm",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.42.0/download",
+          "sha256": "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnullvm 0.42.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_x86_64_msvc 0.36.1": {
       "name": "windows_x86_64_msvc",
       "version": "0.36.1",
@@ -20856,6 +21515,65 @@
         },
         "edition": "2018",
         "version": "0.36.1"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_msvc 0.42.0": {
+      "name": "windows_x86_64_msvc",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.42.0/download",
+          "sha256": "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_msvc 0.42.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -21004,7 +21722,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.43",
+              "id": "proc-macro2 1.0.47",
               "target": "proc_macro2"
             },
             {
@@ -21012,7 +21730,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.99",
+              "id": "syn 1.0.103",
               "target": "syn"
             },
             {
@@ -21030,8 +21748,8 @@
   },
   "binary_crates": [
     "bindgen 0.59.2",
-    "cc 1.0.73",
-    "clap 3.2.19",
+    "cc 1.0.74",
+    "clap 3.2.23",
     "minicbor 0.18.0",
     "peg-macros 0.6.3",
     "wait-timeout 0.2.0"
@@ -21047,6 +21765,7 @@
     "many-identity-hsm 0.1.0": "src/many-identity-hsm",
     "many-identity-webauthn 0.1.0": "src/many-identity-webauthn",
     "many-macros 0.1.0": "src/many-macros",
+    "many-migration 0.1.0": "src/many-migration",
     "many-mock 0.1.0": "src/many-mock",
     "many-modules 0.1.0": "src/many-modules",
     "many-protocol 0.1.0": "src/many-protocol",
@@ -21060,6 +21779,7 @@
     "aarch64-linux-android": [
       "aarch64-linux-android"
     ],
+    "aarch64-pc-windows-gnullvm": [],
     "aarch64-pc-windows-msvc": [],
     "aarch64-uwp-windows-msvc": [],
     "cfg(all(any(target_arch = \"x86_64\", target_arch = \"aarch64\"), target_os = \"hermit\"))": [],
@@ -21142,6 +21862,30 @@
       "x86_64-apple-darwin",
       "x86_64-apple-ios",
       "x86_64-linux-android",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
     ],
@@ -21311,6 +22055,7 @@
     "i686-uwp-windows-gnu": [],
     "i686-uwp-windows-msvc": [],
     "x86_64-pc-windows-gnu": [],
+    "x86_64-pc-windows-gnullvm": [],
     "x86_64-pc-windows-msvc": [
       "x86_64-pc-windows-msvc"
     ],

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 components = [ "rustfmt", "rustc", "clippy", "llvm-tools-preview" ]
-channel = "1.63.0"
+channel = "nightly"

--- a/src/many-client/src/client.rs
+++ b/src/many-client/src/client.rs
@@ -63,7 +63,7 @@ impl<I: Identity> ManyClient<I> {
         Ok(Self {
             identity,
             to: Some(to),
-            url: url.into_url().map_err(|e| format!("{}", e))?,
+            url: url.into_url().map_err(|e| e.to_string())?,
             verifier,
         })
     }

--- a/src/many-error/src/error.rs
+++ b/src/many-error/src/error.rs
@@ -344,7 +344,7 @@ mod tests {
             arguments,
         );
 
-        assert_eq!(format!("{}", e), "Hello ZERO and TWO.");
+        assert_eq!(e.to_string(), "Hello ZERO and TWO.");
     }
 
     #[test]
@@ -356,7 +356,7 @@ mod tests {
 
         let e = ManyError::new(ErrorCode::Unknown, Some("{2}".to_string()), arguments);
 
-        assert_eq!(format!("{}", e), "TWO");
+        assert_eq!(e.to_string(), "TWO");
     }
 
     #[test]
@@ -372,7 +372,7 @@ mod tests {
             arguments,
         );
 
-        assert_eq!(format!("{}", e), "@.");
+        assert_eq!(e.to_string(), "@.");
     }
 
     #[test]
@@ -388,6 +388,6 @@ mod tests {
             arguments,
         );
 
-        assert_eq!(format!("{}", e), "/{}{ZERO}{}}{TWO.");
+        assert_eq!(e.to_string(), "/{}{ZERO}{}}{TWO.");
     }
 }

--- a/src/many-identity-dsa/src/impls/ecdsa.rs
+++ b/src/many-identity-dsa/src/impls/ecdsa.rs
@@ -224,7 +224,7 @@ impl EcDsaVerifier {
             .as_slice();
         let points = p256::EncodedPoint::from_affine_coordinates(x.into(), y.into(), false);
         let pk = p256::ecdsa::VerifyingKey::from_encoded_point(&points)
-            .map_err(|e| ManyError::unknown(format!("Could not create a verifying key: {}", e)))?;
+            .map_err(|e| ManyError::unknown(format!("Could not create a verifying key: {e}")))?;
 
         Ok(Self { address, pk })
     }
@@ -247,8 +247,8 @@ impl Verifier for EcDsaVerifier {
             Ok(address)
         } else {
             Err(ManyError::unknown(format!(
-                "Address in envelope does not match expected address. Expected: {}, Actual: {}",
-                self.address, address
+                "Address in envelope does not match expected address. Expected: {}, Actual: {address}",
+                self.address
             )))
         }
     }

--- a/src/many-identity-dsa/src/impls/ed25519.rs
+++ b/src/many-identity-dsa/src/impls/ed25519.rs
@@ -294,8 +294,8 @@ impl Verifier for Ed25519Verifier {
             Ok(address)
         } else {
             Err(ManyError::unknown(format!(
-                "Address in envelope does not match expected address. Expected: {}, Actual: {}",
-                self.address, address
+                "Address in envelope does not match expected address. Expected: {}, Actual: {address}",
+                self.address
             )))
         }
     }

--- a/src/many-identity-hsm/src/lib.rs
+++ b/src/many-identity-hsm/src/lib.rs
@@ -216,7 +216,7 @@ impl Hsm {
         trace!("Decoding EC_POINT using ASN.1 DER");
         let raw_points: &[u8] = asn1::parse_single(ec_points)
             .map_err(|e| ManyError::hsm_ec_point_error(format!("{e:?}")))?;
-        trace!("Raw, uncompressed EC_POINT: {}", hex::encode(&raw_points));
+        trace!("Raw, uncompressed EC_POINT: {}", hex::encode(raw_points));
         Ok((raw_points.to_vec(), ec_params.clone()))
     }
 

--- a/src/many-identity/src/address.rs
+++ b/src/many-identity/src/address.rs
@@ -63,7 +63,7 @@ impl TryInto<SubresourceId> for u32 {
         if self > MAX_SUBRESOURCE_ID {
             Err(ManyError::invalid_identity_subid())
         } else {
-            Ok(SubresourceId(self as u32))
+            Ok(SubresourceId(self))
         }
     }
 }

--- a/src/many-macros/src/lib.rs
+++ b/src/many-macros/src/lib.rs
@@ -274,7 +274,7 @@ impl Endpoint {
             quote_spanned! { span => {
                 let protected = std::collections::BTreeMap::from_iter(envelope.protected.header.rest.clone().into_iter());
                 if !protected.contains_key(&coset::Label::Text("webauthn".to_string())) {
-                    return Err( many_error::ManyError::non_webauthn_request_denied(method))
+                    return Err(many_error::ManyError::non_webauthn_request_denied(method))
                 }
             }}
         } else {

--- a/src/many-macros/src/lib.rs
+++ b/src/many-macros/src/lib.rs
@@ -256,7 +256,7 @@ impl Endpoint {
         let span = self.span;
         let name = self.name.as_str().to_camel_case();
         let ep = match namespace {
-            Some(ref namespace) => format!("{}.{}", namespace, name),
+            Some(ref namespace) => format!("{namespace}.{name}"),
             None => name,
         };
 
@@ -274,7 +274,7 @@ impl Endpoint {
             quote_spanned! { span => {
                 let protected = std::collections::BTreeMap::from_iter(envelope.protected.header.rest.clone().into_iter());
                 if !protected.contains_key(&coset::Label::Text("webauthn".to_string())) {
-                    return Err( many_error::ManyError::non_webauthn_request_denied(&method))
+                    return Err( many_error::ManyError::non_webauthn_request_denied(method))
                 }
             }}
         } else {
@@ -303,7 +303,7 @@ impl Endpoint {
         let span = self.span;
         let name = self.name.as_str().to_camel_case();
         let ep = match namespace {
-            Some(ref namespace) => format!("{}.{}", namespace, name),
+            Some(ref namespace) => format!("{namespace}.{name}"),
             None => name,
         };
         let ep_ident = &self.func;
@@ -381,17 +381,17 @@ fn many_module_impl(attr: &TokenStream, item: TokenStream) -> Result<TokenStream
 
     let vis = tr.vis.clone();
     let trait_ident = if attrs.name.is_none() {
-        Ident::new(&format!("{}Backend", struct_name), tr.ident.span())
+        Ident::new(&format!("{struct_name}Backend"), tr.ident.span())
     } else {
         tr.ident.clone()
     };
 
     let attr_id = attrs.id.iter();
     let attr_name =
-        inflections::Inflect::to_constant_case(format!("{}Attribute", struct_name).as_str());
+        inflections::Inflect::to_constant_case(format!("{struct_name}Attribute").as_str());
     let attr_ident = Ident::new(&attr_name, attr.span());
 
-    let info_name = format!("{}Info", struct_name);
+    let info_name = format!("{struct_name}Info");
     let info_ident = Ident::new(&info_name, attr.span());
 
     let endpoints: Vec<Endpoint> = tr
@@ -422,7 +422,7 @@ fn many_module_impl(attr: &TokenStream, item: TokenStream) -> Result<TokenStream
         .map(|e| {
             let name = e.name.as_str().to_camel_case();
             match &namespace {
-                Some(ref namespace) => format!("{}.{}", namespace, name),
+                Some(ref namespace) => format!("{namespace}.{name}"),
                 None => name,
             }
         })

--- a/src/many-migration/BUILD.bazel
+++ b/src/many-migration/BUILD.bazel
@@ -1,12 +1,43 @@
-load("@crate_index//:defs.bzl", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 rust_library(
     name = "many-migration",
     srcs = glob(include = ["src/**/*.rs"]),
     proc_macro_deps = all_crate_deps(
+        proc_macro = True,
     ),
     deps = all_crate_deps(
         normal = True,
     ),
+)
+rust_library(
+    name = "many-migration-for-test",
+    srcs = glob(include = ["src/**/*.rs"]),
+    aliases = aliases(),
+    crate_name = "many_migration",
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+rust_test_suite(
+    name = "many-migration-test-suite",
+    srcs = glob(include = ["tests/*.rs"]),
+    aliases = aliases(),
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + [
+        ":many-migration-for-test",
+    ],
 )

--- a/src/many-migration/BUILD.bazel
+++ b/src/many-migration/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@crate_index//:defs.bzl", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "many-migration",
+    srcs = glob(include = ["src/**/*.rs"]),
+    proc_macro_deps = all_crate_deps(
+    ),
+    deps = all_crate_deps(
+        normal = True,
+    ),
+)

--- a/src/many-migration/Cargo.toml
+++ b/src/many-migration/Cargo.toml
@@ -11,3 +11,6 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 strum = { version = "0.24", features = ["derive"] }
 tracing = "0.1.37"
+
+[dev-dependencies]
+linkme = "0.3.5"

--- a/src/many-migration/Cargo.toml
+++ b/src/many-migration/Cargo.toml
@@ -13,4 +13,4 @@ strum = { version = "0.24", features = ["derive"] }
 tracing = "0.1.37"
 
 [dev-dependencies]
-linkme = "0.3.5"
+linkme = { version = "0.3.5", features = ["used_linker"] }

--- a/src/many-migration/Cargo.toml
+++ b/src/many-migration/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+minicbor = { version = "0.18.0", features = ["derive"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 strum = { version = "0.24", features = ["derive"] }

--- a/src/many-migration/Cargo.toml
+++ b/src/many-migration/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "many-migration"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.147", features = ["derive"] }
+serde_json = "1.0.87"
+strum = { version = "0.24", features = ["derive"] }
+tracing = "0.1.37"

--- a/src/many-migration/src/lib.rs
+++ b/src/many-migration/src/lib.rs
@@ -421,7 +421,7 @@ impl<'a, T, E> InnerMigration<'a, T, E> {
 }
 
 #[derive(Deserialize)]
-struct IO<'a> {
+struct MigrationJson<'a> {
     r#type: &'a str,
 
     #[serde(flatten)]
@@ -433,7 +433,7 @@ pub fn load_migrations<'a, 'b, E, T>(
     data: &'a str,
 ) -> Result<BTreeMap<&'b str, Migration<'b, T, E>>, String> {
     // TODO: Do not hardcode the deserializer
-    let config: Vec<IO> = serde_json::from_str(data).unwrap();
+    let config: Vec<MigrationJson> = serde_json::from_str(data).unwrap();
 
     // TODO: Cache this
     // Build a BTreeMap from the linear registry
@@ -455,12 +455,12 @@ pub fn load_migrations<'a, 'b, E, T>(
         .collect())
 }
 
-/// Enable all migrations from the registry EXCEPT the hotfix
+// /// Enable all migrations from the registry EXCEPT the hotfix
 pub fn load_enable_all_regular_migrations<'a, E, T>(
     registry: &'a [InnerMigration<'a, T, E>],
 ) -> BTreeMap<&'a str, Migration<'a, T, E>> {
     registry
-        .iter()
+        .into_iter()
         .map(|m| {
             (
                 m.name,

--- a/src/many-migration/src/lib.rs
+++ b/src/many-migration/src/lib.rs
@@ -10,7 +10,7 @@ use tracing::trace;
 pub type FnPtr<T, E> = dyn Sync + Fn(&mut T) -> Result<(), E>;
 pub type FnByte = fn(&[u8]) -> Option<Vec<u8>>;
 
-#[derive(Default, Deserialize, Display, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Display, PartialEq, Eq)]
 pub enum Status {
     Enabled,
     #[default]
@@ -52,8 +52,18 @@ pub enum MigrationType<'a, T, E> {
     Hotfix(HotfixMigration),
 }
 
+// TODO: DRY
 impl<'a, T, E> fmt::Display for MigrationType<'a, T, E> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(match self {
+            MigrationType::Regular(_) => "Regular",
+            MigrationType::Hotfix(_) => "Hotfix",
+        })
+    }
+}
+
+impl<'a, T, E> fmt::Debug for MigrationType<'a, T, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> std::fmt::Result {
         formatter.write_str(match self {
             MigrationType::Regular(_) => "Regular",
             MigrationType::Hotfix(_) => "Hotfix",
@@ -90,6 +100,17 @@ impl<'a, T, E> fmt::Display for InnerMigration<'a, T, E> {
     }
 }
 
+impl<'a, T, E> fmt::Debug for InnerMigration<'a, T, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> std::fmt::Result {
+        formatter
+            .debug_struct("InnerMigration")
+            .field("type", &self.r#type)
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .finish()
+    }
+}
+
 pub struct Migration<'a, T, E> {
     pub migration: &'a InnerMigration<'a, T, E>,
     pub metadata: Metadata,
@@ -104,6 +125,15 @@ impl<'a, T, E> fmt::Display for Migration<'a, T, E> {
             self.metadata(),
             self.status()
         ))
+    }
+}
+impl<'a, T, E> fmt::Debug for Migration<'a, T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Migration")
+            .field("migration", &self.migration)
+            .field("metadata", &self.metadata)
+            .field("status", &self.status)
+            .finish()
     }
 }
 

--- a/src/many-migration/src/lib.rs
+++ b/src/many-migration/src/lib.rs
@@ -1,0 +1,343 @@
+#![feature(const_mut_refs)]
+
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+use strum::Display;
+use tracing::trace;
+
+pub type FnPtr<T, E> = dyn Sync + Fn(&mut T) -> Result<(), E>;
+pub type FnByte = fn(&[u8]) -> Option<Vec<u8>>;
+
+#[derive(Default, Deserialize, Display, PartialEq, Eq)]
+pub enum Status {
+    Enabled,
+    #[default]
+    Disabled,
+}
+
+impl Status {
+    pub fn enabled() -> Self {
+        Status::Enabled
+    }
+
+    pub fn disabled() -> Self {
+        Status::Disabled
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Metadata {
+    pub block_height: u64,
+    pub issue: Option<String>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl Default for Metadata {
+    fn default() -> Self {
+        Self {
+            block_height: 1,
+            issue: None,
+            extra: HashMap::default(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum MigrationType<'a, T, E> {
+    Regular(RegularMigration<'a, T, E>),
+    Hotfix(HotfixMigration),
+}
+
+impl<'a, T, E> fmt::Display for MigrationType<'a, T, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(match self {
+            MigrationType::Regular(_) => "Regular",
+            MigrationType::Hotfix(_) => "Hotfix",
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct RegularMigration<'a, T, E> {
+    initialize_fn: &'a FnPtr<T, E>,
+    update_fn: &'a FnPtr<T, E>,
+}
+
+#[derive(Clone)]
+pub struct HotfixMigration {
+    hotfix_fn: FnByte,
+}
+
+#[derive(Clone)]
+pub struct InnerMigration<'a, T, E> {
+    r#type: MigrationType<'a, T, E>,
+    name: &'a str,
+    description: &'a str,
+}
+
+impl<'a, T, E> fmt::Display for InnerMigration<'a, T, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_fmt(format_args!(
+            "Type: \"{}\", Name: \"{}\", Description: \"{}\"",
+            self.r#type(),
+            self.name(),
+            self.description()
+        ))
+    }
+}
+
+pub struct Migration<'a, T, E> {
+    pub migration: &'a InnerMigration<'a, T, E>,
+    pub metadata: Metadata,
+    pub status: Status,
+}
+
+impl<'a, T, E> fmt::Display for Migration<'a, T, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_fmt(format_args!(
+            "{}, Metadata: \"{:?}\", Status: \"{}\"",
+            self.migration,
+            self.metadata(),
+            self.status()
+        ))
+    }
+}
+
+impl<'a, T, E> Migration<'a, T, E> {
+    pub const fn new(
+        migration: &'a InnerMigration<'a, T, E>,
+        metadata: Metadata,
+        status: Status,
+    ) -> Self {
+        Self {
+            migration,
+            metadata,
+            status,
+        }
+    }
+
+    /// This function gets executed when the storage block height == the migration block height
+    pub fn initialize(&self, storage: &mut T, h: u64) -> Result<(), E> {
+        if self.status == Status::Enabled && self.metadata().block_height == h {
+            trace!("Trying to initialize migration - {}", self.name());
+            return self.migration.initialize(storage);
+        }
+        Ok(())
+    }
+
+    /// This function gets executed when the storage block height >= the migration block height
+    pub fn update(&self, storage: &mut T, h: u64) -> Result<(), E> {
+        if self.status == Status::Enabled && self.metadata().block_height >= h {
+            trace!("Trying to update migration - {}", self.name());
+            return self.migration.update(storage);
+        }
+        Ok(())
+    }
+
+    /// This function gets executed when the storage block height == the migration block height
+    pub fn hotfix<'b>(&'b self, b: &'b [u8], h: u64) -> Option<Vec<u8>> {
+        if self.status == Status::Enabled && self.metadata().block_height == h {
+            trace!("Trying to execute hotfix - {}", self.name());
+            return self.migration.hotfix(b);
+        }
+        None
+    }
+
+    pub fn name(&self) -> &'a str {
+        self.migration.name()
+    }
+
+    pub fn description(&self) -> &'a str {
+        self.migration.description()
+    }
+
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    pub fn status(&self) -> &Status {
+        &self.status
+    }
+
+    pub fn disable(&mut self) {
+        self.status = Status::Disabled
+    }
+
+    pub fn enable(&mut self) {
+        self.status = Status::Enabled
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.status == Status::Enabled
+    }
+}
+
+impl<'a, T, E> InnerMigration<'a, T, E> {
+    pub const fn new_hotfix(hotfix_fn: FnByte, name: &'a str, description: &'a str) -> Self {
+        Self {
+            r#type: MigrationType::Hotfix(HotfixMigration { hotfix_fn }),
+            name,
+            description,
+        }
+    }
+
+    pub const fn new_initialize_update(
+        initialize_fn: &'a FnPtr<T, E>,
+        update_fn: &'a FnPtr<T, E>,
+        name: &'a str,
+        description: &'a str,
+    ) -> Self {
+        Self {
+            r#type: MigrationType::Regular(RegularMigration {
+                initialize_fn,
+                update_fn,
+            }),
+            name,
+            description,
+        }
+    }
+
+    pub const fn new_initialize(
+        initialize_fn: &'a FnPtr<T, E>,
+        name: &'a str,
+        description: &'a str,
+    ) -> Self {
+        Self {
+            r#type: MigrationType::Regular(RegularMigration {
+                initialize_fn,
+                update_fn: &|_| Ok(()),
+            }),
+            name,
+            description,
+        }
+    }
+
+    pub const fn new_update(
+        update_fn: &'a FnPtr<T, E>,
+        name: &'a str,
+        description: &'a str,
+    ) -> Self {
+        Self {
+            r#type: MigrationType::Regular(RegularMigration {
+                initialize_fn: &|_| Ok(()),
+                update_fn,
+            }),
+            name,
+            description,
+        }
+    }
+
+    pub const fn name(&self) -> &'a str {
+        self.name
+    }
+
+    pub const fn description(&self) -> &'a str {
+        self.description
+    }
+
+    pub const fn r#type(&self) -> &MigrationType<'a, T, E> {
+        &self.r#type
+    }
+
+    /// This function gets executed when the storage block height == the migration block height
+    pub fn initialize(&self, storage: &mut T) -> Result<(), E> {
+        match &self.r#type {
+            MigrationType::Regular(migration) => (migration.initialize_fn)(storage),
+            _ => {
+                tracing::trace!(
+                    "Migration {} is not of type `Regular`, skipping",
+                    self.name()
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// This function gets executed when the storage block height >= the migration block height
+    pub fn update(&self, storage: &mut T) -> Result<(), E> {
+        match &self.r#type {
+            MigrationType::Regular(migration) => (migration.update_fn)(storage),
+            _ => {
+                tracing::trace!(
+                    "Migration {} is not of type `Regular`, skipping",
+                    self.name()
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// This function gets executed when the storage block height == the migration block height
+    pub fn hotfix<'b>(&'b self, b: &'b [u8]) -> Option<Vec<u8>> {
+        match &self.r#type {
+            MigrationType::Hotfix(migration) => (migration.hotfix_fn)(b),
+            _ => {
+                tracing::trace!(
+                    "Migration {} is not of type `Hotfix`, skipping",
+                    self.name()
+                );
+                None
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct IO<'a> {
+    r#type: &'a str,
+
+    #[serde(flatten)]
+    metadata: Metadata,
+}
+
+pub fn load_migrations<'de: 'a, 'a, 'b, E, T>(
+    registry: &'b [InnerMigration<'b, T, E>],
+    data: &'a str,
+) -> Result<BTreeMap<&'b str, Migration<'b, T, E>>, String> {
+    // TODO: Do not hardcode the deserializer
+    let config: Vec<IO> = serde_json::from_str(data).unwrap();
+
+    // Build a BTreeMap from the linear registry
+    let registry = registry
+        .iter()
+        .map(|m| (m.name, m))
+        .collect::<BTreeMap<&'b str, &InnerMigration<'b, T, E>>>();
+
+    Ok(config
+        .into_iter()
+        .map(|io| {
+            let (&k, &v) = registry
+                .get_key_value(io.r#type)
+                .ok_or_else(|| format!("Unsupported migration type {}", io.r#type))?;
+            Ok((k, Migration::new(v, io.metadata, Status::Enabled)))
+        })
+        .collect::<Result<BTreeMap<_, _>, String>>()?
+        .into_iter()
+        .collect())
+}
+
+/// Enable all migrations from the registry EXCEPT the hotfix
+pub fn load_enable_all_regular_migrations<'a, E, T>(
+    registry: &'a [InnerMigration<'a, T, E>],
+) -> BTreeMap<&'a str, Migration<'a, T, E>> {
+    registry
+        .iter()
+        .map(|m| {
+            (
+                m.name,
+                Migration::new(
+                    m,
+                    Metadata::default(),
+                    match m.r#type {
+                        MigrationType::Regular(_) => Status::Enabled,
+                        MigrationType::Hotfix(_) => Status::Disabled,
+                    },
+                ),
+            )
+        })
+        .collect()
+}

--- a/src/many-migration/src/lib.rs
+++ b/src/many-migration/src/lib.rs
@@ -460,7 +460,7 @@ pub fn load_enable_all_regular_migrations<'a, E, T>(
     registry: &'a [InnerMigration<'a, T, E>],
 ) -> BTreeMap<&'a str, Migration<'a, T, E>> {
     registry
-        .into_iter()
+        .iter()
         .map(|m| {
             (
                 m.name,

--- a/src/many-migration/tests/migrations.rs
+++ b/src/many-migration/tests/migrations.rs
@@ -1,0 +1,261 @@
+use linkme::distributed_slice;
+use many_migration::{
+    load_enable_all_regular_migrations, load_migrations, InnerMigration, Migration, Status,
+};
+use std::collections::{BTreeMap, HashMap};
+use std::str::FromStr;
+
+type Storage = BTreeMap<String, String>;
+
+#[distributed_slice]
+static MIGRATIONS: [InnerMigration<'static, Storage, String>] = [..];
+
+fn _initialize(s: &mut Storage) -> Result<(), String> {
+    s.insert("Init".to_string(), "Okay".to_string());
+    Ok(())
+}
+
+fn _update(s: &mut Storage) -> Result<(), String> {
+    if let Some(counter) = s.get("Counter") {
+        let mut counter = u8::from_str(counter).unwrap();
+        counter += 1;
+        s.insert("Counter".to_string(), counter.to_string());
+        return Ok(());
+    }
+    Err("Counter entry not found".to_string())
+}
+
+fn _hotfix(data: &[u8]) -> Option<Vec<u8>> {
+    let mut new_data = [0u8; 4];
+    if data.len() == 8 {
+        new_data.copy_from_slice(&data[0..4]);
+        return Some(new_data.to_vec());
+    }
+    None
+}
+
+#[distributed_slice(MIGRATIONS)]
+static A: InnerMigration<Storage, String> =
+    InnerMigration::new_initialize(&_initialize, "A", "A desc");
+
+#[distributed_slice(MIGRATIONS)]
+static B: InnerMigration<Storage, String> = InnerMigration::new_update(&_update, "B", "B desc");
+
+#[distributed_slice(MIGRATIONS)]
+static C: InnerMigration<Storage, String> =
+    InnerMigration::new_initialize_update(&_initialize, &_update, "C", "C desc");
+
+#[distributed_slice(MIGRATIONS)]
+static D: InnerMigration<Storage, String> = InnerMigration::new_hotfix(_hotfix, "D", "D desc");
+
+#[test]
+fn initialize() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    assert!(migrations.contains_key("A"));
+
+    let mut storage = Storage::new();
+
+    // Should not run when block height == 0
+    migrations["A"].initialize(&mut storage, 0).unwrap();
+    assert!(storage.is_empty());
+
+    // Migration should run when block height == 1
+    migrations["A"].initialize(&mut storage, 1).unwrap();
+    assert!(!storage.is_empty());
+    assert_eq!(storage.len(), 1);
+    assert!(storage.contains_key("Init"));
+    assert_eq!(storage.get("Init").unwrap(), "Okay");
+
+    // Should not do anything after it ran once
+    migrations["A"].initialize(&mut storage, 2).unwrap();
+    assert_eq!(storage.len(), 1);
+}
+
+#[test]
+fn update() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    assert!(migrations.contains_key("B"));
+
+    let mut storage = Storage::new();
+    storage.insert("Counter".to_string(), "0".to_string());
+
+    // Should not run when block height == 0
+    migrations["B"].update(&mut storage, 0).unwrap();
+    assert_eq!(storage["Counter"], "0".to_string());
+
+    // Should not run when block height == 1
+    migrations["B"].update(&mut storage, 1).unwrap();
+    assert_eq!(storage["Counter"], "0".to_string());
+
+    // Should run when block height is > 1
+    for i in 2..10 {
+        migrations["B"].update(&mut storage, 2).unwrap();
+        assert_eq!(storage["Counter"], (i - 1).to_string());
+    }
+}
+
+#[test]
+fn initialize_update() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    assert!(migrations.contains_key("C"));
+
+    let mut storage = Storage::new();
+    storage.insert("Counter".to_string(), "0".to_string());
+
+    for i in 0..4 {
+        migrations["C"].initialize(&mut storage, i).unwrap();
+        match i {
+            0 => assert_eq!(storage.len(), 1),
+            1 => {
+                assert_eq!(storage.len(), 2);
+                assert!(storage.contains_key("Init"));
+                assert_eq!(storage.get("Init").unwrap(), "Okay");
+            }
+            2 => assert_eq!(storage.len(), 2),
+            3 => assert_eq!(storage.len(), 2),
+            _ => unimplemented!(),
+        }
+
+        migrations["C"].update(&mut storage, i).unwrap();
+
+        match i {
+            0 => {
+                assert_eq!(storage.len(), 1);
+                assert_eq!(storage["Counter"], "0".to_string());
+            }
+            1 => {
+                assert_eq!(storage.len(), 2);
+                assert_eq!(storage["Counter"], "0".to_string());
+            }
+            2 => {
+                assert_eq!(storage.len(), 2);
+                assert_eq!(storage["Counter"], "1".to_string());
+            }
+            3 => {
+                assert_eq!(storage.len(), 2);
+                assert_eq!(storage["Counter"], "2".to_string());
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[test]
+fn hotfix() {
+    let content = r#"
+    [
+        {
+            "type": "D",
+            "block_height": 2
+        }
+    ]
+    "#;
+    let migrations = load_migrations(&MIGRATIONS, content).unwrap();
+    assert!(migrations.contains_key("D"));
+
+    let data = [1u8; 8];
+    for i in 0..4 {
+        let maybe_new_data = migrations["D"].hotfix(&data, i);
+
+        match i {
+            0..=1 | 3 => assert!(maybe_new_data.is_none()),
+            2 => {
+                assert!(maybe_new_data.is_some());
+                assert_eq!(maybe_new_data.unwrap(), vec![1, 1, 1, 1]);
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[test]
+fn name() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    assert!(migrations.contains_key("A"));
+    assert_eq!(migrations["A"].name(), "A");
+}
+
+#[test]
+fn description() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    assert!(migrations.contains_key("A"));
+    assert_eq!(migrations["A"].description(), "A desc");
+}
+
+#[test]
+fn load_enable_all_regular_hotfix_disabled() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    for k in ["A", "B", "C", "D"] {
+        assert!(migrations.contains_key(k));
+        match k {
+            "A" | "B" | "C" => {
+                assert!(migrations[k].is_enabled())
+            }
+            "D" => assert!(!migrations[k].is_enabled()),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[test]
+fn metadata() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    for migration in migrations.values() {
+        let metadata = migration.metadata();
+        assert_eq!(metadata.block_height, 1);
+        assert_eq!(metadata.issue, None);
+        assert_eq!(metadata.extra, HashMap::new());
+    }
+
+    let content = r#"
+    [
+        {
+            "type": "D",
+            "block_height": 200,
+            "issue": "foobar",
+            "xtra": "Oh!"
+        }
+    ]
+    "#;
+    let migrations = load_migrations(&MIGRATIONS, content).unwrap();
+    let metadata = migrations["D"].metadata();
+    assert_eq!(metadata.block_height, 200);
+    assert_eq!(metadata.issue, Some("foobar".to_string()));
+    assert!(!metadata.extra.is_empty());
+    assert_eq!(metadata.extra.len(), 1);
+    assert!(metadata.extra.contains_key("xtra"));
+    assert_eq!(metadata.extra["xtra"], "Oh!");
+}
+
+#[test]
+fn status() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    for i in ["A", "B", "C", "D"] {
+        let migration = &migrations[i];
+        let status = migration.status();
+
+        match i {
+            "A" | "B" | "C" => assert_eq!(status, &Status::Enabled),
+            "D" => assert_eq!(status, &Status::Disabled),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[test]
+fn encode_decode() {
+    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let cbor = minicbor::to_vec(&migrations).unwrap();
+
+    let result: BTreeMap<&str, Migration<Storage, String>> =
+        minicbor::decode_with(&cbor, &mut MIGRATIONS.clone()).unwrap();
+    for ((orig_name, orig_mig), (res_name, res_mig)) in
+        result.into_iter().zip(migrations.into_iter())
+    {
+        assert_eq!(orig_name, res_name);
+        assert_eq!(orig_mig.name(), res_mig.name());
+        assert_eq!(orig_mig.description(), res_mig.description());
+        assert_eq!(orig_mig.metadata(), res_mig.metadata());
+        assert_eq!(orig_mig.status(), res_mig.status());
+    }
+}

--- a/src/many-migration/tests/migrations.rs
+++ b/src/many-migration/tests/migrations.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 type Storage = BTreeMap<String, String>;
 
 #[distributed_slice]
-static MIGRATIONS: [InnerMigration<'static, Storage, String>] = [..];
+static SOME_MANY_RS_MIGRATIONS: [InnerMigration<'static, Storage, String>] = [..];
 
 fn _initialize(s: &mut Storage) -> Result<(), String> {
     s.insert("Init".to_string(), "Okay".to_string());
@@ -34,23 +34,23 @@ fn _hotfix(data: &[u8]) -> Option<Vec<u8>> {
     None
 }
 
-#[distributed_slice(MIGRATIONS)]
+#[distributed_slice(SOME_MANY_RS_MIGRATIONS)]
 static A: InnerMigration<Storage, String> =
     InnerMigration::new_initialize(&_initialize, "A", "A desc");
 
-#[distributed_slice(MIGRATIONS)]
+#[distributed_slice(SOME_MANY_RS_MIGRATIONS)]
 static B: InnerMigration<Storage, String> = InnerMigration::new_update(&_update, "B", "B desc");
 
-#[distributed_slice(MIGRATIONS)]
+#[distributed_slice(SOME_MANY_RS_MIGRATIONS)]
 static C: InnerMigration<Storage, String> =
     InnerMigration::new_initialize_update(&_initialize, &_update, "C", "C desc");
 
-#[distributed_slice(MIGRATIONS)]
+#[distributed_slice(SOME_MANY_RS_MIGRATIONS)]
 static D: InnerMigration<Storage, String> = InnerMigration::new_hotfix(_hotfix, "D", "D desc");
 
 #[test]
 fn initialize() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     assert!(migrations.contains_key("A"));
 
     let mut storage = Storage::new();
@@ -73,7 +73,7 @@ fn initialize() {
 
 #[test]
 fn update() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     assert!(migrations.contains_key("B"));
 
     let mut storage = Storage::new();
@@ -96,7 +96,7 @@ fn update() {
 
 #[test]
 fn initialize_update() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     assert!(migrations.contains_key("C"));
 
     let mut storage = Storage::new();
@@ -150,7 +150,7 @@ fn hotfix() {
         }
     ]
     "#;
-    let migrations = load_migrations(&MIGRATIONS, content).unwrap();
+    let migrations = load_migrations(&SOME_MANY_RS_MIGRATIONS, content).unwrap();
     assert!(migrations.contains_key("D"));
 
     let data = [1u8; 8];
@@ -170,21 +170,21 @@ fn hotfix() {
 
 #[test]
 fn name() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     assert!(migrations.contains_key("A"));
     assert_eq!(migrations["A"].name(), "A");
 }
 
 #[test]
 fn description() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     assert!(migrations.contains_key("A"));
     assert_eq!(migrations["A"].description(), "A desc");
 }
 
 #[test]
 fn load_enable_all_regular_hotfix_disabled() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     for k in ["A", "B", "C", "D"] {
         assert!(migrations.contains_key(k));
         match k {
@@ -199,7 +199,7 @@ fn load_enable_all_regular_hotfix_disabled() {
 
 #[test]
 fn metadata() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     for migration in migrations.values() {
         let metadata = migration.metadata();
         assert_eq!(metadata.block_height, 1);
@@ -217,7 +217,7 @@ fn metadata() {
         }
     ]
     "#;
-    let migrations = load_migrations(&MIGRATIONS, content).unwrap();
+    let migrations = load_migrations(&SOME_MANY_RS_MIGRATIONS, content).unwrap();
     let metadata = migrations["D"].metadata();
     assert_eq!(metadata.block_height, 200);
     assert_eq!(metadata.issue, Some("foobar".to_string()));
@@ -229,7 +229,7 @@ fn metadata() {
 
 #[test]
 fn status() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     for i in ["A", "B", "C", "D"] {
         let migration = &migrations[i];
         let status = migration.status();
@@ -244,11 +244,11 @@ fn status() {
 
 #[test]
 fn encode_decode() {
-    let migrations = load_enable_all_regular_migrations(&MIGRATIONS);
+    let migrations = load_enable_all_regular_migrations(&SOME_MANY_RS_MIGRATIONS);
     let cbor = minicbor::to_vec(&migrations).unwrap();
 
     let result: BTreeMap<&str, Migration<Storage, String>> =
-        minicbor::decode_with(&cbor, &mut MIGRATIONS.clone()).unwrap();
+        minicbor::decode_with(&cbor, &mut SOME_MANY_RS_MIGRATIONS.clone()).unwrap();
     for ((orig_name, orig_mig), (res_name, res_mig)) in
         result.into_iter().zip(migrations.into_iter())
     {

--- a/src/many-migration/tests/migrations.rs
+++ b/src/many-migration/tests/migrations.rs
@@ -1,3 +1,5 @@
+#![feature(used_with_arg)] // Required to build the test with Bazel
+
 use linkme::distributed_slice;
 use many_migration::{
     load_enable_all_regular_migrations, load_migrations, InnerMigration, Migration, Status,

--- a/src/many-migration/tests/migrations.rs
+++ b/src/many-migration/tests/migrations.rs
@@ -38,14 +38,14 @@ fn _hotfix(data: &[u8]) -> Option<Vec<u8>> {
 
 #[distributed_slice(SOME_MANY_RS_MIGRATIONS)]
 static A: InnerMigration<Storage, String> =
-    InnerMigration::new_initialize(&_initialize, "A", "A desc");
+    InnerMigration::new_initialize(_initialize, "A", "A desc");
 
 #[distributed_slice(SOME_MANY_RS_MIGRATIONS)]
-static B: InnerMigration<Storage, String> = InnerMigration::new_update(&_update, "B", "B desc");
+static B: InnerMigration<Storage, String> = InnerMigration::new_update(_update, "B", "B desc");
 
 #[distributed_slice(SOME_MANY_RS_MIGRATIONS)]
 static C: InnerMigration<Storage, String> =
-    InnerMigration::new_initialize_update(&_initialize, &_update, "C", "C desc");
+    InnerMigration::new_initialize_update(_initialize, _update, "C", "C desc");
 
 #[distributed_slice(SOME_MANY_RS_MIGRATIONS)]
 static D: InnerMigration<Storage, String> = InnerMigration::new_hotfix(_hotfix, "D", "D desc");

--- a/src/many-mock/src/lib.rs
+++ b/src/many-mock/src/lib.rs
@@ -32,7 +32,7 @@ where
             let mut result = BTreeMap::new();
             while let Some((key, value)) = map.next_entry::<String, String>()? {
                 let value_data = cbor_diag::parse_diag(value).map_err(|e| {
-                    serde::de::Error::custom(format!("Deserialization error: {:?}", e))
+                    serde::de::Error::custom(format!("Deserialization error: {e:?}"))
                 })?;
                 let value = value_data.to_bytes();
                 result.insert(key, value);
@@ -48,7 +48,7 @@ where
 pub fn parse_mockfile(mockfile_arg: &str) -> Result<MockEntries, String> {
     let path = std::path::Path::new(mockfile_arg);
     if !path.exists() {
-        return Err(format!("File {:?} does not exist", path));
+        return Err(format!("File {path:?} does not exist"));
     }
     let contents = std::fs::read_to_string(path).map_err(|_| "Error reading file".to_string())?;
     let parsed: MockEntriesWrapper = toml::from_str(&contents)

--- a/src/many-mock/src/server.rs
+++ b/src/many-mock/src/server.rs
@@ -60,9 +60,7 @@ impl<I: Identity + Debug + Send + Sync> LowLevelManyRequestHandler for ManyMockS
 
 impl<I: Identity> base::BaseModuleBackend for ManyMockServer<I> {
     fn endpoints(&self) -> Result<base::Endpoints, ManyError> {
-        Ok(base::Endpoints(
-            self.mock_entries.iter().map(|(k, _)| k.clone()).collect(),
-        ))
+        Ok(base::Endpoints(self.mock_entries.keys().cloned().collect()))
     }
 
     fn status(&self) -> Result<base::Status, ManyError> {

--- a/src/many-modules/src/_0_base.rs
+++ b/src/many-modules/src/_0_base.rs
@@ -41,11 +41,11 @@ pub struct Status {
 
 impl Status {
     pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
-        minicbor::to_vec(self).map_err(|e| format!("{}", e))
+        minicbor::to_vec(self).map_err(|e| e.to_string())
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
-        minicbor::decode(bytes).map_err(|e| format!("{}", e))
+        minicbor::decode(bytes).map_err(|e| e.to_string())
     }
 }
 
@@ -61,7 +61,7 @@ impl<C> Encode<C> for Status {
         }
 
         e.u8(3)?
-            .encode(&self.identity)?
+            .encode(self.identity)?
             .u8(4)?
             .encode(&self.attributes)?;
 

--- a/src/many-modules/src/_4_events.rs
+++ b/src/many-modules/src/_4_events.rs
@@ -160,7 +160,7 @@ impl<C> Encode<C> for EventFilter {
             .u8(3)?
             .encode(&self.id_range)?
             .u8(4)?
-            .encode(&self.date_range)?;
+            .encode(self.date_range)?;
         for (key, value) in self.events_filter_attribute_specific.iter() {
             e.encode(key)?.encode(value)?;
         }
@@ -233,7 +233,7 @@ impl TryFrom<AttributeRelatedIndex> for EventFilterAttributeSpecificIndex {
         if idx == AttributeRelatedIndex::new(9).with_index(1).with_index(0) {
             return Ok(EventFilterAttributeSpecificIndex::MultisigTransactionState);
         }
-        Err(Self::Error::message(format!("Unknown variant {:?}", idx)))
+        Err(Self::Error::message(format!("Unknown variant {idx:?}")))
     }
 }
 
@@ -920,7 +920,7 @@ mod test {
             let bytes = minicbor::to_vec(info.clone()).expect("Could not serialize");
             let decoded: EventInfo = minicbor::decode(&bytes).expect("Could not decode");
 
-            assert_eq!(format!("{:?}", decoded), format!("{:?}", info));
+            assert_eq!(format!("{decoded:?}"), format!("{info:?}"));
         }
 
         proptest! {

--- a/src/many-modules/src/_9_account.rs
+++ b/src/many-modules/src/_9_account.rs
@@ -568,7 +568,7 @@ mod module_tests {
             1,
             &module,
             "account.setDescription",
-            format!(r#"{{ 0: "{}", 1: "new-name" }}"#, id),
+            format!(r#"{{ 0: "{id}", 1: "new-name" }}"#),
         )
         .unwrap();
 
@@ -576,13 +576,13 @@ mod module_tests {
             1,
             &module,
             "account.setDescription",
-            format!(r#"{{ 0: "{}", 1: "new-name-2" }}"#, wrong_id),
+            format!(r#"{{ 0: "{wrong_id}", 1: "new-name-2" }}"#),
         )
         .is_err());
 
         {
             let account: InfoReturn = minicbor::decode(
-                &call_module(0, &module, "account.info", format!(r#"{{ 0: "{}" }}"#, id)).unwrap(),
+                &call_module(0, &module, "account.info", format!(r#"{{ 0: "{id}" }}"#)).unwrap(),
             )
             .unwrap();
             assert_eq!(account.description, Some("new-name".to_string()));
@@ -600,7 +600,7 @@ mod module_tests {
             1,
             &module,
             "account.listRoles",
-            format!(r#"{{ 0: "{}", 1: "new-name" }}"#, wrong_id),
+            format!(r#"{{ 0: "{wrong_id}", 1: "new-name" }}"#),
         )
         .is_err());
 
@@ -610,7 +610,7 @@ mod module_tests {
                     1,
                     &module,
                     "account.listRoles",
-                    format!(r#"{{ 0: "{}", 1: "new-name" }}"#, id)
+                    format!(r#"{{ 0: "{id}", 1: "new-name" }}"#)
                 )
                 .unwrap()
             )
@@ -623,7 +623,7 @@ mod module_tests {
             2,
             &module,
             "account.disable",
-            format!(r#"{{ 0: "{}" }}"#, id),
+            format!(r#"{{ 0: "{id}" }}"#),
         )
         .is_err());
         assert!(call_module(
@@ -638,7 +638,7 @@ mod module_tests {
             1,
             &module,
             "account.disable",
-            format!(r#"{{ 0: "{}" }}"#, id),
+            format!(r#"{{ 0: "{id}" }}"#),
         )
         .is_ok());
 

--- a/src/many-protocol/src/response.rs
+++ b/src/many-protocol/src/response.rs
@@ -110,11 +110,11 @@ impl ResponseMessage {
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
-        minicbor::to_vec(self).map_err(|e| format!("{}", e))
+        minicbor::to_vec(self).map_err(|e| format!("{e}"))
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
-        minicbor::decode(bytes).map_err(|e| format!("{}", e))
+        minicbor::decode(bytes).map_err(|e| format!("{e}"))
     }
 }
 
@@ -122,14 +122,10 @@ impl<C> Encode<C> for ResponseMessage {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, _: &mut C) -> Result<(), Error<W::Error>> {
         e.tag(Tag::Unassigned(10002))?;
         let l = 2
-            + if self.from.is_anonymous() { 0 } else { 1 }
-            + if self.to.is_none() || self.to == Some(Address::anonymous()) {
-                0
-            } else {
-                1
-            }
-            + if self.id.is_none() { 0 } else { 1 }
-            + if self.attributes.is_empty() { 0 } else { 1 };
+            + u64::from(!self.from.is_anonymous())
+            + u64::from(!(self.to.is_none() || self.to == Some(Address::anonymous())))
+            + u64::from(self.id.is_some())
+            + u64::from(!self.attributes.is_empty());
         e.map(l)?;
 
         // Skip version for this version of the protocol. This message implementation
@@ -139,7 +135,7 @@ impl<C> Encode<C> for ResponseMessage {
         // No need to send the anonymous identity.
         if !self.from.is_anonymous() {
             e.i8(ResponseMessageCborKey::From as i8)?
-                .encode(&self.from)?;
+                .encode(self.from)?;
         }
 
         if let Some(ref i) = self.to {
@@ -150,7 +146,7 @@ impl<C> Encode<C> for ResponseMessage {
 
         match &self.data {
             Ok(result) => e.i8(ResponseMessageCborKey::Result as i8)?.bytes(result)?,
-            Err(error) => e.i8(ResponseMessageCborKey::Result as i8)?.encode(&error)?,
+            Err(error) => e.i8(ResponseMessageCborKey::Result as i8)?.encode(error)?,
         };
 
         e.i8(ResponseMessageCborKey::Timestamp as i8)?;

--- a/src/many-types/src/attributes.rs
+++ b/src/many-types/src/attributes.rs
@@ -126,10 +126,10 @@ impl Ord for Attribute {
 impl<C> Encode<C> for Attribute {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, _: &mut C) -> Result<(), Error<W::Error>> {
         if self.arguments.is_empty() {
-            e.u32(self.id as u32)?;
+            e.u32(self.id)?;
         } else {
             e.array(1 + self.arguments.len() as u64)?;
-            e.u32(self.id as u32)?;
+            e.u32(self.id)?;
             for a in &self.arguments {
                 e.encode(a)?;
             }
@@ -159,7 +159,7 @@ impl<'d, C> Decode<'d, C> for Attribute {
                     )),
                 }
             }
-            _ => Ok(Self::id(d.u32()? as u32)),
+            _ => Ok(Self::id(d.u32()?)),
         }
     }
 }
@@ -256,7 +256,7 @@ mod tests {
 
         #[test]
         fn debug_fmt(attr in arb_attr()) {
-            assert_eq!(format!("Attribute {{ id: {}, arguments: {:?} }}", attr.id, attr.arguments), format!("{:?}", attr));
+            assert_eq!(format!("Attribute {{ id: {}, arguments: {:?} }}", attr.id, attr.arguments), format!("{attr:?}"));
         }
     }
 }

--- a/src/many-types/src/cbor.rs
+++ b/src/many-types/src/cbor.rs
@@ -17,12 +17,12 @@ pub enum CborAny {
 impl Debug for CborAny {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            CborAny::Bool(b) => write!(f, "{}", b),
-            CborAny::Int(i) => write!(f, "{}", i),
+            CborAny::Bool(b) => write!(f, "{b}"),
+            CborAny::Int(i) => write!(f, "{i}"),
             CborAny::String(s) => f.write_str(s),
             CborAny::Bytes(b) => write!(f, r#"b"{}""#, hex::encode(b)),
-            CborAny::Array(a) => write!(f, "{:?}", a),
-            CborAny::Map(m) => write!(f, "{:?}", m),
+            CborAny::Array(a) => write!(f, "{a:?}"),
+            CborAny::Map(m) => write!(f, "{m:?}"),
         }
     }
 }
@@ -53,7 +53,7 @@ impl<C> Encode<C> for CborAny {
                 }
             }
             CborAny::Map(m) => {
-                e.encode(&m)?;
+                e.encode(m)?;
             }
         }
 

--- a/src/many-types/src/either.rs
+++ b/src/many-types/src/either.rs
@@ -479,7 +479,7 @@ impl<L, R> Either<L, R> {
         match self {
             Either::Left(l) => l,
             Either::Right(r) => {
-                panic!("called `Either::unwrap_left()` on a `Right` value: {:?}", r)
+                panic!("called `Either::unwrap_left()` on a `Right` value: {r:?}")
             }
         }
     }
@@ -509,7 +509,7 @@ impl<L, R> Either<L, R> {
     {
         match self {
             Either::Right(r) => r,
-            Either::Left(l) => panic!("called `Either::unwrap_right()` on a `Left` value: {:?}", l),
+            Either::Left(l) => panic!("called `Either::unwrap_right()` on a `Left` value: {l:?}"),
         }
     }
 
@@ -538,7 +538,7 @@ impl<L, R> Either<L, R> {
     {
         match self {
             Either::Left(l) => l,
-            Either::Right(r) => panic!("{}: {:?}", msg, r),
+            Either::Right(r) => panic!("{msg}: {r:?}"),
         }
     }
 
@@ -567,7 +567,7 @@ impl<L, R> Either<L, R> {
     {
         match self {
             Either::Right(r) => r,
-            Either::Left(l) => panic!("{}: {:?}", msg, l),
+            Either::Left(l) => panic!("{msg}: {l:?}"),
         }
     }
 }
@@ -871,7 +871,7 @@ where
     type Target = L::Target;
 
     fn deref(&self) -> &Self::Target {
-        either!(*self, ref inner => &**inner)
+        either!(*self, ref inner => inner)
     }
 }
 
@@ -930,7 +930,7 @@ fn basic() {
 fn deref() {
     fn is_str(_: &str) {}
     let value: Either<String, &str> = Left(String::from("test"));
-    is_str(&*value);
+    is_str(&value);
 }
 
 #[test]

--- a/src/many/src/main.rs
+++ b/src/many/src/main.rs
@@ -205,9 +205,9 @@ async fn show_response<'a>(
         fn progress(str: &str, done: bool) {
             if atty::is(atty::Stream::Stderr) {
                 if done {
-                    eprintln!("{}", str);
+                    eprintln!("{str}");
                 } else {
-                    eprint!("{}", str);
+                    eprint!("{str}");
                 }
             }
         }
@@ -344,7 +344,7 @@ async fn main() {
                                 .with_subresource_id(subid)
                                 .expect("Invalid subresource id");
                         }
-                        println!("{}", i)
+                        println!("{i}")
                     }
                     Err(e) => {
                         error!("Identity did not parse: {:?}", e.to_string());
@@ -357,17 +357,17 @@ async fn main() {
                         .with_subresource_id(subid)
                         .expect("Invalid subresource id");
                 }
-                println!("{}", hex::encode(&i.to_vec()));
+                println!("{}", hex::encode(i.to_vec()));
             } else if let Ok(pem_content) = std::fs::read_to_string(&o.arg) {
                 // Create the identity from the public key hash.
-                let mut i = CoseKeyIdentity::from_pem(&pem_content).unwrap().address();
+                let mut i = CoseKeyIdentity::from_pem(pem_content).unwrap().address();
                 if let Some(subid) = o.subid {
                     i = i
                         .with_subresource_id(subid)
                         .expect("Invalid subresource id");
                 }
 
-                println!("{}", i);
+                println!("{i}");
             } else {
                 error!("Could not understand the argument.");
                 std::process::exit(2);
@@ -396,7 +396,7 @@ async fn main() {
                     .expect("Invalid subresource id");
             }
 
-            println!("{}", id);
+            println!("{id}");
         }
         SubCommand::Message(o) => {
             let to_identity = o.to.unwrap_or_default();
@@ -407,7 +407,7 @@ async fn main() {
             });
             let data = o
                 .data
-                .map_or(vec![], |d| cbor_diag::parse_diag(&d).unwrap().to_bytes());
+                .map_or(vec![], |d| cbor_diag::parse_diag(d).unwrap().to_bytes());
 
             let from_identity: Box<dyn Identity> = if let (Some(module), Some(slot), Some(keyid)) =
                 (o.module, o.slot, o.keyid)
@@ -435,7 +435,7 @@ async fn main() {
                 )
             } else if let Some(p) = o.pem {
                 // If `pem` is not provided, use anonymous and don't sign.
-                Box::new(CoseKeyIdentity::from_pem(&std::fs::read_to_string(&p).unwrap()).unwrap())
+                Box::new(CoseKeyIdentity::from_pem(std::fs::read_to_string(p).unwrap()).unwrap())
             } else {
                 Box::new(AnonymousIdentity)
             };
@@ -540,7 +540,7 @@ async fn main() {
                 .ok_or_else(|| format!("Could not resolve symbol '{}'", &symbol))
                 .unwrap();
 
-            println!("{}", id);
+            println!("{id}");
         }
     }
 }


### PR DESCRIPTION
Self-contained crate. First iteration. This PR requires Rust nightly.

Relates liftedinit/roadmap#29

**Every change not in `many-migration` is to fix nightly clippies.**

- Migration registry is a static, global distributed slice using the `linkme` crate
- One can add migration to the registry from anywhere
- Support "hotfix" migrations 
  - run once at a given block height
  - allow modifying given byte data
- Support "regular" migration
  - initialization function is run once at a given block height
  - update function is run when current block height > block height
- Encode/decode to/from CBOR
- One can load migration from JSON files
- Support metadata
  - `block_height`
  - `issue` : Url to relevant GitHub issue
  - `extra` : catch-all
- Unit tested


TODO
- Documentation
- Optimisations