### PR TITLE
Unchecked function should be marked unsafe

### DIFF
--- a/src/many-identity-dsa/src/impls/ecdsa.rs
+++ b/src/many-identity-dsa/src/impls/ecdsa.rs
@@ -84,7 +84,7 @@ impl EcDsaIdentityInner {
         check_key(cose_key, true, false, KeyType::EC2, Algorithm::ES256, None)?;
 
         let public_key = public_key(cose_key)?.ok_or_else(|| ManyError::unknown("Invalid key."))?;
-        let address = cose::address_unchecked(&public_key)?;
+        let address = unsafe { cose::address_unchecked(&public_key) }?;
 
         let params = BTreeMap::from_iter(cose_key.params.iter().cloned());
         let d = params
@@ -207,7 +207,7 @@ impl EcDsaVerifier {
             public_key(cose_key)?.ok_or_else(|| ManyError::unknown("Key not EcDsa."))?;
 
         check_key(cose_key, false, true, KeyType::EC2, Algorithm::ES256, None)?;
-        let address = cose::address_unchecked(&public_key)?;
+        let address = unsafe { cose::address_unchecked(&public_key) }?;
 
         let params = BTreeMap::from_iter(cose_key.params.clone().into_iter());
         let x = params
@@ -333,7 +333,7 @@ pub mod tests {
             "magcncsncbfmfdvezjmfick47pwgefjnm6zcaghu7ffe3o3qtf"
         );
         assert_eq!(
-            cose::address_unchecked(&id.public_key().unwrap()).unwrap(),
+            unsafe { cose::address_unchecked(&id.public_key().unwrap()).unwrap() },
             "magcncsncbfmfdvezjmfick47pwgefjnm6zcaghu7ffe3o3qtf"
         );
     }

--- a/src/many-identity-dsa/src/impls/ed25519.rs
+++ b/src/many-identity-dsa/src/impls/ed25519.rs
@@ -124,7 +124,7 @@ impl Ed25519IdentityInner {
     pub fn from_key(cose_key: &CoseKey) -> Result<Self, ManyError> {
         let public_key = public_key(cose_key)?.ok_or_else(|| ManyError::unknown("Invalid key."))?;
         let key_pair = key_pair(cose_key)?;
-        let address = cose::address_unchecked(&public_key)?;
+        let address = unsafe { cose::address_unchecked(&public_key) }?;
 
         Ok(Self {
             address,
@@ -252,7 +252,7 @@ impl Ed25519Verifier {
     pub fn from_key(cose_key: &CoseKey) -> Result<Self, ManyError> {
         let public_key =
             public_key(cose_key)?.ok_or_else(|| ManyError::unknown("Key not ed25519."))?;
-        let address = cose::address_unchecked(&public_key)?;
+        let address = unsafe { cose::address_unchecked(&public_key) }?;
 
         check_key(
             &public_key,
@@ -348,7 +348,7 @@ pub mod tests {
             "maffbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wijp"
         );
         assert_eq!(
-            cose::address_unchecked(&id.public_key()).unwrap(),
+            unsafe { cose::address_unchecked(&id.public_key()).unwrap() },
             "maffbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wijp"
         );
     }

--- a/src/many-identity-hsm/src/lib.rs
+++ b/src/many-identity-hsm/src/lib.rs
@@ -329,7 +329,7 @@ impl HsmIdentity {
         );
         let public_key = many_identity_dsa::ecdsa::public_key(&key)?
             .ok_or_else(|| ManyError::unknown("Could not load key."))?;
-        let address = cose::address_unchecked(&public_key)?;
+        let address = unsafe { cose::address_unchecked(&public_key) }?;
         Ok(Self { address, key })
     }
 }

--- a/src/many-identity/src/address.rs
+++ b/src/many-identity/src/address.rs
@@ -184,7 +184,7 @@ impl Address {
     /// many-identity-dsa) or in the testing utilities available here to create
     /// a bogus address.
     #[inline(always)]
-    pub fn public_key_unchecked(hash: PublicKeyHash) -> Self {
+    pub(crate) fn public_key_unchecked(hash: PublicKeyHash) -> Self {
         Self(InnerAddress::public_key(hash))
     }
 }

--- a/src/many-identity/src/cose.rs
+++ b/src/many-identity/src/cose.rs
@@ -9,7 +9,7 @@ use sha3::{Digest, Sha3_224};
 /// # Safety
 /// This methods DOES NOT VERIFY that the cose key is of a public key. There are
 /// strict criteria (see spec) for how to define the public key of a COSE Key.
-pub fn address_unchecked(cose_key: &CoseKey) -> Result<Address, ManyError> {
+pub unsafe fn address_unchecked(cose_key: &CoseKey) -> Result<Address, ManyError> {
     let pk = Sha3_224::digest(
         cose_key
             .clone()


### PR DESCRIPTION
Fixes a clippy error, but also this function should really be marked unsafe (like other unchecked functions in std library).
