### PR TITLE
Return an error instead of panicking

### DIFF
--- a/src/many-modules/src/_7_kvstore_commands/put.rs
+++ b/src/many-modules/src/_7_kvstore_commands/put.rs
@@ -32,7 +32,7 @@ fn decode_key<C>(d: &mut minicbor::Decoder, _: &mut C) -> Result<ByteVec, minicb
             }
             Ok(data.to_vec().into())
         }
-        _ => unimplemented!(),
+        _ => Err(minicbor::decode::Error::message("Wrong key type. Expected bytes")),
     }
 }
 
@@ -49,7 +49,7 @@ fn decode_value<C>(
             }
             Ok(data.to_vec().into())
         }
-        _ => unimplemented!(),
+        _ => Err(minicbor::decode::Error::message("Wrong key type. Expected bytes")),
     }
 }
 

--- a/src/many-modules/src/_7_kvstore_commands/put.rs
+++ b/src/many-modules/src/_7_kvstore_commands/put.rs
@@ -91,6 +91,16 @@ mod tests {
             "decode error: Value size over limit"
         );
     }
+
+    // Test covering issue https://github.com/liftedinit/operations/issues/21
+    #[test]
+    fn key_not_byte() {
+        let payload = "{0: \"foo\", 1: \"bar\"}";
+        let payload_cbor = cbor_diag::parse_diag(payload).unwrap().to_bytes();
+        let res = minicbor::decode::<PutArgs>(&payload_cbor);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().to_string(), "decode error: Wrong key type. Expected bytes");
+    }
 }
 
 pub type PutReturn = EmptyReturn;


### PR DESCRIPTION
Fixes a potential attack vector.

Fixes https://github.com/liftedinit/operations/issues/21