### PR TITLE
Upgrade Bazel rules_rust to 0.15

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 # Taken from the Bazel `rules_rust` Github repository
+build --@rules_rust//rust/toolchain/channel=nightly
 
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,20 +2,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "dd79bd4e2e2adabae738c5e93c36d351cf18071ff2acf6590190acf4138984f6",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.14.0/rules_rust-v0.14.0.tar.gz"],
+    sha256 = "5c2b6745236f8ce547f82eeacbbcc81d736734cc8bd92e60d3e3cdfa6e167bb5",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.15.0/rules_rust-v0.15.0.tar.gz"],
 )
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
 
 rules_rust_dependencies()
 
-RUST_VERSION = "nightly"
+RUST_VERSION = "nightly/2022-11-13"
 
 rust_register_toolchains(
     edition = "2021",
-    iso_date = "2022-11-13",
-    version = RUST_VERSION,
+    versions = [RUST_VERSION],
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")


### PR DESCRIPTION
This commit includes a workaround for a `rust_register_toolchains` regression between 0.14 and 0.15