### PR TITLE
Remove pretty colors from syslog

### DIFF
--- a/src/kvstore/src/main.rs
+++ b/src/kvstore/src/main.rs
@@ -347,7 +347,7 @@ fn main() {
             let (options, facility) = Default::default();
             let syslog = syslog_tracing::Syslog::new(identity, options, facility).unwrap();
 
-            let subscriber = subscriber.with_writer(syslog);
+            let subscriber = subscriber.with_ansi(false).with_writer(syslog);
             subscriber.init();
         }
     };

--- a/src/many-abci/src/main.rs
+++ b/src/many-abci/src/main.rs
@@ -119,7 +119,7 @@ async fn main() {
             let (options, facility) = Default::default();
             let syslog = syslog_tracing::Syslog::new(identity, options, facility).unwrap();
 
-            let subscriber = subscriber.with_writer(syslog);
+            let subscriber = subscriber.with_ansi(false).with_writer(syslog);
             subscriber.init();
         }
     };


### PR DESCRIPTION
It was disabled in ledger, not kvstore and abci.
