### PR TITLE
Sort merk Ops in mint/burn

### DIFF
--- a/src/many-ledger/src/storage/ledger_mintburn.rs
+++ b/src/many-ledger/src/storage/ledger_mintburn.rs
@@ -66,6 +66,10 @@ impl LedgerStorage {
             Op::Put(minicbor::to_vec(&info).map_err(ManyError::serialization_error)?),
         ));
 
+        // We need to sort here because `distribution` is sorted by Address (bytes)
+        // while the `merk` Ops are sorted by String
+        batch.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+
         self.persistent_store
             .apply(batch.as_slice())
             .map_err(error::storage_apply_failed)?;
@@ -119,6 +123,10 @@ impl LedgerStorage {
             key_for_symbol(&symbol).into(),
             Op::Put(minicbor::to_vec(&info).map_err(ManyError::serialization_error)?),
         ));
+
+        // We need to sort here because `distribution` is sorted by Address (bytes)
+        // while the `merk` Ops are sorted by String
+        batch.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
 
         self.persistent_store
             .apply(batch.as_slice())

--- a/src/many-ledger/src/storage/ledger_tokens.rs
+++ b/src/many-ledger/src/storage/ledger_tokens.rs
@@ -291,7 +291,10 @@ impl LedgerStorage {
             memo,
         })?;
 
+        // We need to sort here because `initial_distribution` is sorted by Address (bytes)
+        // while the `merk` Ops are sorted by String
         batch.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+
         self.persistent_store
             .apply(batch.as_slice())
             .map_err(error::storage_apply_failed)?;

--- a/tests/e2e/ledger/tokens.bats
+++ b/tests/e2e/ledger/tokens.bats
@@ -67,6 +67,15 @@ function teardown() {
     assert_output --partial "1000 FBR"
 }
 
+# Relates to https://github.com/liftedinit/many-rs/issues/291
+@test "$SUITE: create initial distribution ordering" {
+    create_token --pem=1 --port=8000 --initial-distribution ''\''{"mahtbpgjmrhjrqn6smpd6rr5tkgnkd3w2qjioe3dzfhnl2tqxj": 123, "mah2yupaotgppckhdb57vl54vmh7idujleerpwegq53ie7oqaz": 456}'\'''
+    call_ledger --port=8000 balance mahtbpgjmrhjrqn6smpd6rr5tkgnkd3w2qjioe3dzfhnl2tqxj
+    assert_output --partial "123 FBR"
+    call_ledger --port=8000 balance mah2yupaotgppckhdb57vl54vmh7idujleerpwegq53ie7oqaz
+    assert_output --partial "456 FBR"
+}
+
 @test "$SUITE: token create doesn't overwrite existing subresource" {
     # Create FBR
     create_token --pem=1 --port=8000


### PR DESCRIPTION
- Add tests
- Add preventive test for `token.create`

Fixes #291
