### PR TITLE
More bats fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
       - bats/install
       - run:
           name: running BATs tests
+          no_output_timeout: 20m
           command: bats *
           working_directory: ./tests/e2e/
   dev_release_artifact:
@@ -299,6 +300,7 @@ jobs:
           name: running BATs tests
           # https://support.circleci.com/hc/en-us/articles/360046544433-Makefile-Command-Inconsistencies
           shell: /bin/bash
+          no_output_timeout: 20m
           command: bats *
           working_directory: ./tests/resiliency
   tag:

--- a/tests/resiliency/ledger/persistent_store.bats
+++ b/tests/resiliency/ledger/persistent_store.bats
@@ -103,7 +103,7 @@ EOT
 
     # Give time to the servers to start.
     timeout 60s bash <<EOT
-    while ! many message --server http://localhost:8003 status; do
+    while ! "$GIT_ROOT/target/debug/many" message --server http://localhost:8003 status; do
       sleep 1
     done >/dev/null
 EOT


### PR DESCRIPTION
- Fix the last call to `many`
- Extend no output timeout for bats tests