### PR TITLE
Fix nightly toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 components = [ "rustfmt", "rustc", "clippy", "llvm-tools-preview" ]
-channel = "nightly"
+channel = "nightly-2023-01-03"


### PR DESCRIPTION
Fix `rust-toolchain.toml` nightly version to match Bazel/CI.