### PR TITLE
Add common cli flags to a single crate

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrayref"
@@ -214,7 +214,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ dependencies = [
  "futures-lite",
  "libc",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -276,9 +276,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -438,6 +438,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -542,9 +543,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
 dependencies = [
  "memchr",
  "serde",
@@ -576,9 +577,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -610,14 +611,14 @@ dependencies = [
  "num-traits",
  "separator",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -757,7 +758,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -770,7 +771,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -820,7 +821,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -842,7 +843,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1171,12 +1172,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
- "darling_core 0.14.2",
- "darling_macro 0.14.2",
+ "darling_core 0.14.3",
+ "darling_macro 0.14.3",
 ]
 
 [[package]]
@@ -1195,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1220,11 +1221,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
- "darling_core 0.14.2",
+ "darling_core 0.14.3",
  "quote",
  "syn",
 ]
@@ -1321,7 +1322,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling 0.14.2",
+ "darling 0.14.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1413,9 +1414,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "drain_filter_polyfill"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9f76bdd86dfc8d64eecb0484d02ad4cf0e6767d4682f686d1b0580b6c27f82"
+checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
 name = "ecdsa"
@@ -1488,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -1516,18 +1517,18 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "enum-iterator"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+checksum = "9ea166b3f7dc1032f7866d13f8d8e02c8d87507b61750176b86554964dc6a7bf"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -1623,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.22.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e55932f129b8e8582d2099dd43f67c9e641a9369280fac04ac97c47ba1564e"
+checksum = "55f3be4cf4fc227d3a63bb77512a2b7d364200b2a715f389155785c4d3345495"
 dependencies = [
  "az",
  "bytemuck",
@@ -1690,9 +1691,9 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1705,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1715,15 +1716,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1732,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -1753,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1764,21 +1765,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1861,7 +1862,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8f8f49b2b547ec22cc4d99f3bf30d4889ef0dbaa231c0736eeaf20efb5a38e"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "peg 0.6.3",
  "quote",
  "serde",
@@ -1891,9 +1892,9 @@ checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "git2"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -2022,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -2043,6 +2044,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -2146,9 +2153,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2328,12 +2335,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2344,14 +2351,14 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2380,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2452,7 +2459,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "lazy_static",
- "log-panics",
+ "many-cli-helpers",
  "many-client",
  "many-error",
  "many-identity",
@@ -2468,10 +2475,8 @@ dependencies = [
  "ring",
  "rpassword 6.0.1",
  "serde_json",
- "syslog-tracing",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2515,12 +2520,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
+name = "libm"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.8.3+7.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
 dependencies = [
- "bindgen 0.60.1",
+ "bindgen 0.64.0",
  "bzip2-sys",
  "cc",
  "glob",
@@ -2633,6 +2644,7 @@ dependencies = [
  "clap 3.2.23",
  "coset",
  "hex",
+ "many-cli-helpers",
  "many-client",
  "many-error",
  "many-identity",
@@ -2665,7 +2677,7 @@ dependencies = [
  "itertools",
  "json5",
  "lazy_static",
- "log-panics",
+ "many-cli-helpers",
  "many-client",
  "many-error",
  "many-identity",
@@ -2681,15 +2693,24 @@ dependencies = [
  "sha2 0.10.6",
  "signal-hook",
  "smol",
- "syslog-tracing",
  "tendermint",
  "tendermint-abci",
  "tendermint-proto",
  "tendermint-rpc",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "vergen",
+]
+
+[[package]]
+name = "many-cli-helpers"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.23",
+ "log-panics",
+ "syslog-tracing",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2868,7 +2889,7 @@ dependencies = [
  "itertools",
  "json5",
  "lazy_static",
- "log-panics",
+ "many-cli-helpers",
  "many-error",
  "many-identity",
  "many-identity-dsa",
@@ -2886,11 +2907,9 @@ dependencies = [
  "signal-hook",
  "simple_asn1",
  "strum",
- "syslog-tracing",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "vergen",
 ]
 
@@ -2910,7 +2929,7 @@ dependencies = [
  "itertools",
  "json5",
  "linkme",
- "log-panics",
+ "many-cli-helpers",
  "many-client",
  "many-error",
  "many-identity",
@@ -2937,11 +2956,9 @@ dependencies = [
  "signal-hook",
  "simple_asn1",
  "strum",
- "syslog-tracing",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "typenum",
  "typetag",
  "vergen",
@@ -3250,7 +3267,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3424,6 +3441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3582,15 +3600,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3712,9 +3730,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3722,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf026e2d0581559db66d837fe5242320f525d85c76283c61f4d51a1238d65ea"
+checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3732,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b27bd18aa01d91c8ed2b61ea23406a676b42d82609c6e2581fba42f0c15f17f"
+checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3745,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02b677c1859756359fc9983c2e56a0237f18624a3789528804406b7e915e5d"
+checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
 dependencies = [
  "once_cell",
  "pest",
@@ -3844,7 +3862,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3919,18 +3937,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -3944,6 +3962,7 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -4237,16 +4256,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4322,7 +4341,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4379,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4423,9 +4442,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -4463,9 +4482,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -4589,9 +4608,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4599,9 +4618,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -4734,7 +4753,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4845,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
@@ -4987,7 +5006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5047,10 +5066,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -5105,15 +5125,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5126,7 +5146,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5142,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -5163,9 +5183,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5192,9 +5212,9 @@ checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
 
 [[package]]
 name = "toml_edit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
 dependencies = [
  "indexmap",
  "nom8",
@@ -5330,6 +5350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5371,9 +5397,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -5413,9 +5439,9 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom 0.2.8",
  "serde",
@@ -5441,9 +5467,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.5.0"
+version = "7.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571b69f690c855821462709b6f41d42ceccc316fbd17b60bd06d06928cfe6a99"
+checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -5513,9 +5539,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -5523,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -5538,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5550,9 +5576,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5560,9 +5586,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5573,15 +5599,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5604,7 +5630,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
  "webauthn-rs-proto",
 ]
 
@@ -5618,7 +5644,7 @@ dependencies = [
  "serde",
  "tracing",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
  "webauthn-rs-core",
 ]
 
@@ -5641,7 +5667,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
  "webauthn-rs-proto",
  "x509-parser",
 ]
@@ -5733,6 +5759,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrayref"
@@ -214,7 +214,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ dependencies = [
  "futures-lite",
  "libc",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -438,6 +438,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -542,9 +543,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
 dependencies = [
  "memchr",
  "serde",
@@ -610,7 +611,7 @@ dependencies = [
  "num-traits",
  "separator",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -757,7 +758,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -770,7 +771,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -820,7 +821,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -842,7 +843,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1171,12 +1172,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
- "darling_core 0.14.2",
- "darling_macro 0.14.2",
+ "darling_core 0.14.3",
+ "darling_macro 0.14.3",
 ]
 
 [[package]]
@@ -1195,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1220,11 +1221,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
- "darling_core 0.14.2",
+ "darling_core 0.14.3",
  "quote",
  "syn",
 ]
@@ -1321,7 +1322,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling 0.14.2",
+ "darling 0.14.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1413,9 +1414,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "drain_filter_polyfill"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9f76bdd86dfc8d64eecb0484d02ad4cf0e6767d4682f686d1b0580b6c27f82"
+checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
 name = "ecdsa"
@@ -1516,18 +1517,18 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "enum-iterator"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+checksum = "9ea166b3f7dc1032f7866d13f8d8e02c8d87507b61750176b86554964dc6a7bf"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -1623,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.22.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e55932f129b8e8582d2099dd43f67c9e641a9369280fac04ac97c47ba1564e"
+checksum = "55f3be4cf4fc227d3a63bb77512a2b7d364200b2a715f389155785c4d3345495"
 dependencies = [
  "az",
  "bytemuck",
@@ -1861,7 +1862,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8f8f49b2b547ec22cc4d99f3bf30d4889ef0dbaa231c0736eeaf20efb5a38e"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "peg 0.6.3",
  "quote",
  "serde",
@@ -1891,9 +1892,9 @@ checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "git2"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -2022,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -2043,6 +2044,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -2146,9 +2153,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2328,12 +2335,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2344,14 +2351,14 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2380,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2452,7 +2459,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "lazy_static",
- "log-panics",
+ "many-cli-helpers",
  "many-client",
  "many-error",
  "many-identity",
@@ -2468,10 +2475,8 @@ dependencies = [
  "ring",
  "rpassword 6.0.1",
  "serde_json",
- "syslog-tracing",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2515,12 +2520,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
+name = "libm"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.8.3+7.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
 dependencies = [
- "bindgen 0.60.1",
+ "bindgen 0.64.0",
  "bzip2-sys",
  "cc",
  "glob",
@@ -2633,6 +2644,7 @@ dependencies = [
  "clap 3.2.23",
  "coset",
  "hex",
+ "many-cli-helpers",
  "many-client",
  "many-error",
  "many-identity",
@@ -2665,7 +2677,7 @@ dependencies = [
  "itertools",
  "json5",
  "lazy_static",
- "log-panics",
+ "many-cli-helpers",
  "many-client",
  "many-error",
  "many-identity",
@@ -2681,15 +2693,24 @@ dependencies = [
  "sha2 0.10.6",
  "signal-hook",
  "smol",
- "syslog-tracing",
  "tendermint",
  "tendermint-abci",
  "tendermint-proto",
  "tendermint-rpc",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "vergen",
+]
+
+[[package]]
+name = "many-cli-helpers"
+version = "0.1.0"
+dependencies = [
+ "clap 3.2.23",
+ "log-panics",
+ "syslog-tracing",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2868,7 +2889,7 @@ dependencies = [
  "itertools",
  "json5",
  "lazy_static",
- "log-panics",
+ "many-cli-helpers",
  "many-error",
  "many-identity",
  "many-identity-dsa",
@@ -2886,11 +2907,9 @@ dependencies = [
  "signal-hook",
  "simple_asn1",
  "strum",
- "syslog-tracing",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "vergen",
 ]
 
@@ -2910,7 +2929,7 @@ dependencies = [
  "itertools",
  "json5",
  "linkme",
- "log-panics",
+ "many-cli-helpers",
  "many-client",
  "many-error",
  "many-identity",
@@ -2937,11 +2956,9 @@ dependencies = [
  "signal-hook",
  "simple_asn1",
  "strum",
- "syslog-tracing",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "typenum",
  "typetag",
  "vergen",
@@ -3250,7 +3267,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3424,6 +3441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3582,15 +3600,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3712,9 +3730,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3722,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf026e2d0581559db66d837fe5242320f525d85c76283c61f4d51a1238d65ea"
+checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3732,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b27bd18aa01d91c8ed2b61ea23406a676b42d82609c6e2581fba42f0c15f17f"
+checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3745,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02b677c1859756359fc9983c2e56a0237f18624a3789528804406b7e915e5d"
+checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
 dependencies = [
  "once_cell",
  "pest",
@@ -3844,7 +3862,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3919,18 +3937,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -3944,6 +3962,7 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -4237,16 +4256,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4322,7 +4341,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4423,9 +4442,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -4463,9 +4482,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -4589,9 +4608,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4599,9 +4618,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -4734,7 +4753,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4845,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
@@ -4987,7 +5006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5047,10 +5066,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -5105,9 +5125,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5126,7 +5146,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5142,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -5163,9 +5183,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5330,6 +5350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5413,9 +5439,9 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom 0.2.8",
  "serde",
@@ -5441,9 +5467,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.5.0"
+version = "7.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571b69f690c855821462709b6f41d42ceccc316fbd17b60bd06d06928cfe6a99"
+checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -5513,9 +5539,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -5523,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -5538,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5550,9 +5576,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5560,9 +5586,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5573,15 +5599,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5604,7 +5630,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
  "webauthn-rs-proto",
 ]
 
@@ -5618,7 +5644,7 @@ dependencies = [
  "serde",
  "tracing",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
  "webauthn-rs-core",
 ]
 
@@ -5641,7 +5667,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
  "webauthn-rs-proto",
  "x509-parser",
 ]
@@ -5733,6 +5759,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -47,6 +47,7 @@ crates_repository(
         "//src/ledger-db:Cargo.toml",
         "//src/ledger:Cargo.toml",
         "//src/many-abci:Cargo.toml",
+        "//src/many-cli-helpers:Cargo.toml",
         "//src/many-client-macros:Cargo.toml",
         "//src/many-client:Cargo.toml",
         "//src/many-error:Cargo.toml",

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "eda807de67c0a598482de26b6035e09740c29a109ad637b9af3fc6574ff24207",
+  "checksum": "dd826cd79673957fbb9413c0d2999714b3ee033692e6e54a1ffe8902ee2c95f0",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -283,13 +283,13 @@
       },
       "license": "MIT"
     },
-    "anyhow 1.0.68": {
+    "anyhow 1.0.69": {
       "name": "anyhow",
-      "version": "1.0.68",
+      "version": "1.0.69",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.68/download",
-          "sha256": "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.69/download",
+          "sha256": "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
         }
       },
       "targets": [
@@ -324,14 +324,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.69",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.68"
+        "version": "1.0.69"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -677,7 +677,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -728,7 +728,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -775,7 +775,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -830,7 +830,7 @@
               "target": "event_listener"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             }
           ],
@@ -1270,7 +1270,7 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook 0.3.14",
+                "id": "signal-hook 0.3.15",
                 "target": "signal_hook"
               }
             ],
@@ -1333,7 +1333,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -1386,13 +1386,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-trait 0.1.63": {
+    "async-trait 0.1.64": {
       "name": "async-trait",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-trait/0.1.63/download",
-          "sha256": "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+          "url": "https://crates.io/api/v1/crates/async-trait/0.1.64/download",
+          "sha256": "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
         }
       },
       "targets": [
@@ -1423,11 +1423,11 @@
         "deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -1442,7 +1442,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.63"
+        "version": "0.1.64"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1624,7 +1624,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_bytes 0.11.8",
+              "id": "serde_bytes 0.11.9",
               "target": "serde_bytes"
             },
             {
@@ -1632,7 +1632,7 @@
               "target": "serde_cbor"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -1845,7 +1845,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             }
           ],
@@ -2055,7 +2055,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             }
           ],
@@ -2153,7 +2153,7 @@
               "target": "peeking_take_while"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -2189,20 +2189,20 @@
       },
       "license": "BSD-3-Clause"
     },
-    "bindgen 0.60.1": {
+    "bindgen 0.64.0": {
       "name": "bindgen",
-      "version": "0.60.1",
+      "version": "0.64.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bindgen/0.60.1/download",
-          "sha256": "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+          "url": "https://crates.io/api/v1/crates/bindgen/0.64.0/download",
+          "sha256": "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
         }
       },
       "targets": [
         {
           "Library": {
             "crate_name": "bindgen",
-            "crate_root": "src/lib.rs",
+            "crate_root": "lib.rs",
             "srcs": [
               "**/*.rs"
             ]
@@ -2229,7 +2229,7 @@
         "deps": {
           "common": [
             {
-              "id": "bindgen 0.60.1",
+              "id": "bindgen 0.64.0",
               "target": "build_script_build"
             },
             {
@@ -2257,7 +2257,7 @@
               "target": "peeking_take_while"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -2275,12 +2275,16 @@
             {
               "id": "shlex 1.1.0",
               "target": "shlex"
+            },
+            {
+              "id": "syn 1.0.107",
+              "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.60.1"
+        "version": "0.64.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2522,7 +2526,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             }
           ],
@@ -2781,13 +2785,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "bstr 1.1.0": {
+    "bstr 1.2.0": {
       "name": "bstr",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bstr/1.1.0/download",
-          "sha256": "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+          "url": "https://crates.io/api/v1/crates/bstr/1.2.0/download",
+          "sha256": "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
         }
       },
       "targets": [
@@ -2824,7 +2828,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.0"
+        "version": "1.2.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2956,13 +2960,13 @@
       },
       "license": "Unlicense OR MIT"
     },
-    "bytes 1.3.0": {
+    "bytes 1.4.0": {
       "name": "bytes",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytes/1.3.0/download",
-          "sha256": "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+          "url": "https://crates.io/api/v1/crates/bytes/1.4.0/download",
+          "sha256": "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
         }
       },
       "targets": [
@@ -2996,7 +3000,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.3.0"
+        "version": "1.4.0"
       },
       "license": "MIT"
     },
@@ -3060,7 +3064,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             },
             {
@@ -3142,7 +3146,7 @@
               "target": "url"
             },
             {
-              "id": "uuid 1.2.2",
+              "id": "uuid 1.3.0",
               "target": "uuid"
             }
           ],
@@ -3153,13 +3157,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cc 1.0.78": {
+    "cc 1.0.79": {
       "name": "cc",
-      "version": "1.0.78",
+      "version": "1.0.79",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.78/download",
-          "sha256": "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+          "url": "https://crates.io/api/v1/crates/cc/1.0.79/download",
+          "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
         }
       },
       "targets": [
@@ -3192,7 +3196,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.78"
+        "version": "1.0.79"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3844,7 +3848,7 @@
               "target": "clap_lex"
             },
             {
-              "id": "is-terminal 0.4.2",
+              "id": "is-terminal 0.4.3",
               "target": "is_terminal"
             },
             {
@@ -3911,7 +3915,7 @@
         "deps": {
           "common": [
             {
-              "id": "heck 0.4.0",
+              "id": "heck 0.4.1",
               "target": "heck"
             },
             {
@@ -3919,7 +3923,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -3969,7 +3973,7 @@
         "deps": {
           "common": [
             {
-              "id": "heck 0.4.0",
+              "id": "heck 0.4.1",
               "target": "heck"
             },
             {
@@ -3977,7 +3981,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -4176,7 +4180,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -4188,7 +4192,7 @@
               "target": "url"
             },
             {
-              "id": "uuid 1.2.2",
+              "id": "uuid 1.3.0",
               "target": "uuid"
             }
           ],
@@ -4438,7 +4442,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -5154,7 +5158,7 @@
               "target": "bindgen"
             },
             {
-              "id": "target-lexicon 0.12.5",
+              "id": "target-lexicon 0.12.6",
               "target": "target_lexicon"
             }
           ],
@@ -5346,11 +5350,11 @@
               "target": "cucumber_expressions"
             },
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             },
             {
-              "id": "futures 0.3.25",
+              "id": "futures 0.3.26",
               "target": "futures"
             },
             {
@@ -5388,7 +5392,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             },
             {
@@ -5444,7 +5448,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.69",
               "target": "anyhow"
             },
             {
@@ -5464,15 +5468,15 @@
               "target": "cucumber_expressions"
             },
             {
-              "id": "drain_filter_polyfill 0.1.2",
+              "id": "drain_filter_polyfill 0.1.3",
               "target": "drain_filter_polyfill"
             },
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             },
             {
-              "id": "futures 0.3.25",
+              "id": "futures 0.3.26",
               "target": "futures"
             },
             {
@@ -5512,7 +5516,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             }
           ],
@@ -5522,7 +5526,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             },
             {
@@ -5584,7 +5588,7 @@
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -5651,7 +5655,7 @@
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -5712,7 +5716,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             },
             {
@@ -5920,13 +5924,13 @@
       },
       "license": "MIT"
     },
-    "darling 0.14.2": {
+    "darling 0.14.3": {
       "name": "darling",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling/0.14.2/download",
-          "sha256": "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+          "url": "https://crates.io/api/v1/crates/darling/0.14.3/download",
+          "sha256": "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
         }
       },
       "targets": [
@@ -5952,7 +5956,7 @@
         "deps": {
           "common": [
             {
-              "id": "darling_core 0.14.2",
+              "id": "darling_core 0.14.3",
               "target": "darling_core"
             }
           ],
@@ -5962,13 +5966,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "darling_macro 0.14.2",
+              "id": "darling_macro 0.14.3",
               "target": "darling_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.14.2"
+        "version": "0.14.3"
       },
       "license": "MIT"
     },
@@ -6012,7 +6016,7 @@
               "target": "ident_case"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -6035,13 +6039,13 @@
       },
       "license": "MIT"
     },
-    "darling_core 0.14.2": {
+    "darling_core 0.14.3": {
       "name": "darling_core",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling_core/0.14.2/download",
-          "sha256": "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+          "url": "https://crates.io/api/v1/crates/darling_core/0.14.3/download",
+          "sha256": "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
         }
       },
       "targets": [
@@ -6075,7 +6079,7 @@
               "target": "ident_case"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -6094,7 +6098,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.2"
+        "version": "0.14.3"
       },
       "license": "MIT"
     },
@@ -6145,13 +6149,13 @@
       },
       "license": "MIT"
     },
-    "darling_macro 0.14.2": {
+    "darling_macro 0.14.3": {
       "name": "darling_macro",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling_macro/0.14.2/download",
-          "sha256": "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+          "url": "https://crates.io/api/v1/crates/darling_macro/0.14.3/download",
+          "sha256": "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
         }
       },
       "targets": [
@@ -6173,7 +6177,7 @@
         "deps": {
           "common": [
             {
-              "id": "darling_core 0.14.2",
+              "id": "darling_core 0.14.3",
               "target": "darling_core"
             },
             {
@@ -6188,7 +6192,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.2"
+        "version": "0.14.3"
       },
       "license": "MIT"
     },
@@ -6450,7 +6454,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -6587,7 +6591,7 @@
               "target": "darling"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -6634,11 +6638,11 @@
         "deps": {
           "common": [
             {
-              "id": "darling 0.14.2",
+              "id": "darling 0.14.3",
               "target": "darling"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -6780,7 +6784,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -7003,7 +7007,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -7056,13 +7060,13 @@
       },
       "license": "MIT"
     },
-    "drain_filter_polyfill 0.1.2": {
+    "drain_filter_polyfill 0.1.3": {
       "name": "drain_filter_polyfill",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/drain_filter_polyfill/0.1.2/download",
-          "sha256": "ca9f76bdd86dfc8d64eecb0484d02ad4cf0e6767d4682f686d1b0580b6c27f82"
+          "url": "https://crates.io/api/v1/crates/drain_filter_polyfill/0.1.3/download",
+          "sha256": "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
         }
       },
       "targets": [
@@ -7082,7 +7086,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.1.2"
+        "version": "0.1.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7226,7 +7230,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -7411,13 +7415,13 @@
       },
       "license": "BSD-3-Clause"
     },
-    "either 1.8.0": {
+    "either 1.8.1": {
       "name": "either",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/either/1.8.0/download",
-          "sha256": "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+          "url": "https://crates.io/api/v1/crates/either/1.8.1/download",
+          "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
         }
       },
       "targets": [
@@ -7441,9 +7445,9 @@
           "use_std"
         ],
         "edition": "2018",
-        "version": "1.8.0"
+        "version": "1.8.1"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "elliptic-curve 0.10.6": {
       "name": "elliptic-curve",
@@ -7557,13 +7561,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "encoding_rs 0.8.31": {
+    "encoding_rs 0.8.32": {
       "name": "encoding_rs",
-      "version": "0.8.31",
+      "version": "0.8.32",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/encoding_rs/0.8.31/download",
-          "sha256": "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+          "url": "https://crates.io/api/v1/crates/encoding_rs/0.8.32/download",
+          "sha256": "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
         }
       },
       "targets": [
@@ -7571,15 +7575,6 @@
           "Library": {
             "crate_name": "encoding_rs",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": [
               "**/*.rs"
             ]
@@ -7600,31 +7595,22 @@
             {
               "id": "cfg-if 1.0.0",
               "target": "cfg_if"
-            },
-            {
-              "id": "encoding_rs 0.8.31",
-              "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.31"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
+        "version": "0.8.32"
       },
       "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
     },
-    "enum-iterator 1.2.0": {
+    "enum-iterator 1.3.0": {
       "name": "enum-iterator",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/enum-iterator/1.2.0/download",
-          "sha256": "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+          "url": "https://crates.io/api/v1/crates/enum-iterator/1.3.0/download",
+          "sha256": "9ea166b3f7dc1032f7866d13f8d8e02c8d87507b61750176b86554964dc6a7bf"
         }
       },
       "targets": [
@@ -7653,7 +7639,7 @@
           ],
           "selects": {}
         },
-        "version": "1.2.0"
+        "version": "1.3.0"
       },
       "license": "0BSD"
     },
@@ -7685,7 +7671,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -7948,7 +7934,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             }
           ],
@@ -8137,13 +8123,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "fixed 1.22.1": {
+    "fixed 1.23.0": {
       "name": "fixed",
-      "version": "1.22.1",
+      "version": "1.23.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fixed/1.22.1/download",
-          "sha256": "b2e55932f129b8e8582d2099dd43f67c9e641a9369280fac04ac97c47ba1564e"
+          "url": "https://crates.io/api/v1/crates/fixed/1.23.0/download",
+          "sha256": "55f3be4cf4fc227d3a63bb77512a2b7d364200b2a715f389155785c4d3345495"
         }
       },
       "targets": [
@@ -8183,7 +8169,7 @@
               "target": "bytemuck"
             },
             {
-              "id": "fixed 1.22.1",
+              "id": "fixed 1.23.0",
               "target": "build_script_build"
             },
             {
@@ -8198,7 +8184,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.22.1"
+        "version": "1.23.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8476,13 +8462,13 @@
       },
       "license": "Apache-2.0"
     },
-    "futures 0.3.25": {
+    "futures 0.3.26": {
       "name": "futures",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures/0.3.25/download",
-          "sha256": "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+          "url": "https://crates.io/api/v1/crates/futures/0.3.26/download",
+          "sha256": "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
         }
       },
       "targets": [
@@ -8512,48 +8498,48 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.25",
+              "id": "futures-channel 0.3.26",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-executor 0.3.25",
+              "id": "futures-executor 0.3.26",
               "target": "futures_executor"
             },
             {
-              "id": "futures-io 0.3.25",
+              "id": "futures-io 0.3.26",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.25",
+              "id": "futures-sink 0.3.26",
               "target": "futures_sink"
             },
             {
-              "id": "futures-task 0.3.25",
+              "id": "futures-task 0.3.26",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.25",
+              "id": "futures-util 0.3.26",
               "target": "futures_util"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-channel 0.3.25": {
+    "futures-channel 0.3.26": {
       "name": "futures-channel",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-channel/0.3.25/download",
-          "sha256": "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+          "url": "https://crates.io/api/v1/crates/futures-channel/0.3.26/download",
+          "sha256": "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
         }
       },
       "targets": [
@@ -8591,22 +8577,22 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.25",
+              "id": "futures-channel 0.3.26",
               "target": "build_script_build"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.25",
+              "id": "futures-sink 0.3.26",
               "target": "futures_sink"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8615,13 +8601,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-core 0.3.25": {
+    "futures-core 0.3.26": {
       "name": "futures-core",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-core/0.3.25/download",
-          "sha256": "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+          "url": "https://crates.io/api/v1/crates/futures-core/0.3.26/download",
+          "sha256": "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
         }
       },
       "targets": [
@@ -8657,14 +8643,14 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8673,13 +8659,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-executor 0.3.25": {
+    "futures-executor 0.3.26": {
       "name": "futures-executor",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-executor/0.3.25/download",
-          "sha256": "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+          "url": "https://crates.io/api/v1/crates/futures-executor/0.3.26/download",
+          "sha256": "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
         }
       },
       "targets": [
@@ -8704,32 +8690,32 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-task 0.3.25",
+              "id": "futures-task 0.3.26",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.25",
+              "id": "futures-util 0.3.26",
               "target": "futures_util"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-io 0.3.25": {
+    "futures-io 0.3.26": {
       "name": "futures-io",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-io/0.3.25/download",
-          "sha256": "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+          "url": "https://crates.io/api/v1/crates/futures-io/0.3.26/download",
+          "sha256": "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
         }
       },
       "targets": [
@@ -8753,7 +8739,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8799,11 +8785,11 @@
               "target": "fastrand"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.25",
+              "id": "futures-io 0.3.26",
               "target": "futures_io"
             },
             {
@@ -8830,13 +8816,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "futures-macro 0.3.25": {
+    "futures-macro 0.3.26": {
       "name": "futures-macro",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-macro/0.3.25/download",
-          "sha256": "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+          "url": "https://crates.io/api/v1/crates/futures-macro/0.3.26/download",
+          "sha256": "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
         }
       },
       "targets": [
@@ -8858,7 +8844,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -8873,17 +8859,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-sink 0.3.25": {
+    "futures-sink 0.3.26": {
       "name": "futures-sink",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-sink/0.3.25/download",
-          "sha256": "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+          "url": "https://crates.io/api/v1/crates/futures-sink/0.3.26/download",
+          "sha256": "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
         }
       },
       "targets": [
@@ -8908,17 +8894,17 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-task 0.3.25": {
+    "futures-task 0.3.26": {
       "name": "futures-task",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-task/0.3.25/download",
-          "sha256": "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+          "url": "https://crates.io/api/v1/crates/futures-task/0.3.26/download",
+          "sha256": "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
         }
       },
       "targets": [
@@ -8953,14 +8939,14 @@
         "deps": {
           "common": [
             {
-              "id": "futures-task 0.3.25",
+              "id": "futures-task 0.3.26",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8969,13 +8955,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "futures-util 0.3.25": {
+    "futures-util 0.3.26": {
       "name": "futures-util",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-util/0.3.25/download",
-          "sha256": "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+          "url": "https://crates.io/api/v1/crates/futures-util/0.3.26/download",
+          "sha256": "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
         }
       },
       "targets": [
@@ -9022,27 +9008,27 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.25",
+              "id": "futures-channel 0.3.26",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.25",
+              "id": "futures-io 0.3.26",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.25",
+              "id": "futures-sink 0.3.26",
               "target": "futures_sink"
             },
             {
-              "id": "futures-task 0.3.25",
+              "id": "futures-task 0.3.26",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.25",
+              "id": "futures-util 0.3.26",
               "target": "build_script_build"
             },
             {
@@ -9068,13 +9054,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "futures-macro 0.3.25",
+              "id": "futures-macro 0.3.26",
               "target": "futures_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.25"
+        "version": "0.3.26"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9266,11 +9252,11 @@
           "selects": {
             "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))": [
               {
-                "id": "js-sys 0.3.60",
+                "id": "js-sys 0.3.61",
                 "target": "js_sys"
               },
               {
-                "id": "wasm-bindgen 0.2.83",
+                "id": "wasm-bindgen 0.2.84",
                 "target": "wasm_bindgen"
               }
             ],
@@ -9325,7 +9311,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -9435,7 +9421,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -9527,7 +9513,7 @@
         "deps": {
           "common": [
             {
-              "id": "heck 0.4.0",
+              "id": "heck 0.4.1",
               "target": "heck"
             },
             {
@@ -9539,7 +9525,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -9580,7 +9566,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -9633,13 +9619,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "git2 0.15.0": {
+    "git2 0.16.1": {
       "name": "git2",
-      "version": "0.15.0",
+      "version": "0.16.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/git2/0.15.0/download",
-          "sha256": "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+          "url": "https://crates.io/api/v1/crates/git2/0.16.1/download",
+          "sha256": "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
         }
       },
       "targets": [
@@ -9684,7 +9670,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.15.0"
+        "version": "0.16.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -9754,7 +9740,7 @@
               "target": "aho_corasick"
             },
             {
-              "id": "bstr 1.1.0",
+              "id": "bstr 1.2.0",
               "target": "bstr"
             },
             {
@@ -9899,7 +9885,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -9907,15 +9893,15 @@
               "target": "fnv"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.25",
+              "id": "futures-sink 0.3.26",
               "target": "futures_sink"
             },
             {
-              "id": "futures-util 0.3.25",
+              "id": "futures-util 0.3.26",
               "target": "futures_util"
             },
             {
@@ -9931,11 +9917,11 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.7.4",
+              "id": "tokio-util 0.7.7",
               "target": "tokio_util"
             },
             {
@@ -10102,7 +10088,7 @@
               "target": "bitflags"
             },
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -10200,7 +10186,7 @@
         "deps": {
           "common": [
             {
-              "id": "unicode-segmentation 1.10.0",
+              "id": "unicode-segmentation 1.10.1",
               "target": "unicode_segmentation"
             }
           ],
@@ -10211,13 +10197,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "heck 0.4.0": {
+    "heck 0.4.1": {
       "name": "heck",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/heck/0.4.0/download",
-          "sha256": "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+          "url": "https://crates.io/api/v1/crates/heck/0.4.1/download",
+          "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
         }
       },
       "targets": [
@@ -10240,7 +10226,7 @@
           "default"
         ],
         "edition": "2018",
-        "version": "0.4.0"
+        "version": "0.4.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -10327,6 +10313,39 @@
         "version": "0.2.6"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "hermit-abi 0.3.1": {
+      "name": "hermit-abi",
+      "version": "0.3.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/hermit-abi/0.3.1/download",
+          "sha256": "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "hermit_abi",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "hermit_abi",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default"
+        ],
+        "edition": "2021",
+        "version": "0.3.1"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "hex 0.4.3": {
       "name": "hex",
@@ -10442,7 +10461,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             },
             {
@@ -10566,7 +10585,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -10613,7 +10632,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -10673,7 +10692,7 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -10809,13 +10828,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "hyper 0.14.23": {
+    "hyper 0.14.24": {
       "name": "hyper",
-      "version": "0.14.23",
+      "version": "0.14.24",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hyper/0.14.23/download",
-          "sha256": "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+          "url": "https://crates.io/api/v1/crates/hyper/0.14.24/download",
+          "sha256": "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
         }
       },
       "targets": [
@@ -10847,19 +10866,19 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
-              "id": "futures-channel 0.3.25",
+              "id": "futures-channel 0.3.26",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-util 0.3.25",
+              "id": "futures-util 0.3.26",
               "target": "futures_util"
             },
             {
@@ -10895,7 +10914,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -10914,7 +10933,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.14.23"
+        "version": "0.14.24"
       },
       "license": "MIT"
     },
@@ -10954,11 +10973,11 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
-              "id": "futures 0.3.25",
+              "id": "futures 0.3.26",
               "target": "futures"
             },
             {
@@ -10970,7 +10989,7 @@
               "target": "http"
             },
             {
-              "id": "hyper 0.14.23",
+              "id": "hyper 0.14.24",
               "target": "hyper"
             },
             {
@@ -10982,7 +11001,7 @@
               "target": "rustls_native_certs"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -11045,11 +11064,11 @@
               "target": "ct_logs"
             },
             {
-              "id": "futures-util 0.3.25",
+              "id": "futures-util 0.3.26",
               "target": "futures_util"
             },
             {
-              "id": "hyper 0.14.23",
+              "id": "hyper 0.14.24",
               "target": "hyper"
             },
             {
@@ -11065,7 +11084,7 @@
               "target": "rustls_native_certs"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -11116,11 +11135,11 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
-              "id": "hyper 0.14.23",
+              "id": "hyper 0.14.24",
               "target": "hyper"
             },
             {
@@ -11128,11 +11147,11 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
-              "id": "tokio-native-tls 0.3.0",
+              "id": "tokio-native-tls 0.3.1",
               "target": "tokio_native_tls"
             }
           ],
@@ -11245,7 +11264,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             }
           ],
@@ -11317,7 +11336,7 @@
               "target": "same_file"
             },
             {
-              "id": "thread_local 1.1.4",
+              "id": "thread_local 1.1.7",
               "target": "thread_local"
             },
             {
@@ -11650,13 +11669,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "io-lifetimes 1.0.4": {
+    "io-lifetimes 1.0.5": {
       "name": "io-lifetimes",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/io-lifetimes/1.0.4/download",
-          "sha256": "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+          "url": "https://crates.io/api/v1/crates/io-lifetimes/1.0.5/download",
+          "sha256": "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
         }
       },
       "targets": [
@@ -11693,7 +11712,7 @@
         "deps": {
           "common": [
             {
-              "id": "io-lifetimes 1.0.4",
+              "id": "io-lifetimes 1.0.5",
               "target": "build_script_build"
             }
           ],
@@ -11706,14 +11725,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.42.0",
+                "id": "windows-sys 0.45.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "1.0.4"
+        "version": "1.0.5"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11755,13 +11774,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "is-terminal 0.4.2": {
+    "is-terminal 0.4.3": {
       "name": "is-terminal",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/is-terminal/0.4.2/download",
-          "sha256": "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+          "url": "https://crates.io/api/v1/crates/is-terminal/0.4.3/download",
+          "sha256": "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
         }
       },
       "targets": [
@@ -11783,33 +11802,33 @@
         "deps": {
           "common": [
             {
-              "id": "io-lifetimes 1.0.4",
+              "id": "io-lifetimes 1.0.5",
               "target": "io_lifetimes"
             }
           ],
           "selects": {
             "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
               {
-                "id": "rustix 0.36.7",
+                "id": "rustix 0.36.8",
                 "target": "rustix"
               }
             ],
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "hermit-abi 0.2.6",
+                "id": "hermit-abi 0.3.1",
                 "target": "hermit_abi"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.42.0",
+                "id": "windows-sys 0.45.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.4.2"
+        "version": "0.4.3"
       },
       "license": "MIT"
     },
@@ -11846,7 +11865,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             }
           ],
@@ -11928,13 +11947,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "js-sys 0.3.60": {
+    "js-sys 0.3.61": {
       "name": "js-sys",
-      "version": "0.3.60",
+      "version": "0.3.61",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/js-sys/0.3.60/download",
-          "sha256": "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+          "url": "https://crates.io/api/v1/crates/js-sys/0.3.61/download",
+          "sha256": "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
         }
       },
       "targets": [
@@ -11956,14 +11975,14 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen 0.2.83",
+              "id": "wasm-bindgen 0.2.84",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.60"
+        "version": "0.3.61"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -11995,7 +12014,7 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.5.4",
+              "id": "pest 2.5.5",
               "target": "pest"
             },
             {
@@ -12009,7 +12028,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pest_derive 2.5.4",
+              "id": "pest_derive 2.5.5",
               "target": "pest_derive"
             }
           ],
@@ -12097,7 +12116,7 @@
               "target": "syslog_tracing"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -12217,10 +12236,6 @@
               "target": "lazy_static"
             },
             {
-              "id": "log-panics 2.1.0",
-              "target": "log_panics"
-            },
-            {
               "id": "mime_guess 2.0.4",
               "target": "mime_guess"
             },
@@ -12245,24 +12260,16 @@
               "target": "rpassword"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
-              "id": "syslog-tracing 0.1.0",
-              "target": "syslog_tracing"
-            },
-            {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
               "id": "tracing 0.1.37",
               "target": "tracing"
-            },
-            {
-              "id": "tracing-subscriber 0.3.16",
-              "target": "tracing_subscriber"
             }
           ],
           "selects": {}
@@ -12427,7 +12434,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             },
             {
@@ -12488,13 +12495,69 @@
       },
       "license": "ISC"
     },
-    "librocksdb-sys 0.8.0+7.4.4": {
-      "name": "librocksdb-sys",
-      "version": "0.8.0+7.4.4",
+    "libm 0.2.6": {
+      "name": "libm",
+      "version": "0.2.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/librocksdb-sys/0.8.0+7.4.4/download",
-          "sha256": "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+          "url": "https://crates.io/api/v1/crates/libm/0.2.6/download",
+          "sha256": "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "libm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "libm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "libm 0.2.6",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.2.6"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "librocksdb-sys 0.8.3+7.4.4": {
+      "name": "librocksdb-sys",
+      "version": "0.8.3+7.4.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/librocksdb-sys/0.8.3+7.4.4/download",
+          "sha256": "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
         }
       },
       "targets": [
@@ -12537,7 +12600,7 @@
               "target": "libc"
             },
             {
-              "id": "librocksdb-sys 0.8.0+7.4.4",
+              "id": "librocksdb-sys 0.8.3+7.4.4",
               "target": "build_script_build"
             },
             {
@@ -12548,7 +12611,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.0+7.4.4"
+        "version": "0.8.3+7.4.4"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12557,11 +12620,11 @@
         "deps": {
           "common": [
             {
-              "id": "bindgen 0.60.1",
+              "id": "bindgen 0.64.0",
               "target": "bindgen"
             },
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             },
             {
@@ -12752,7 +12815,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             },
             {
@@ -12876,7 +12939,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -13117,7 +13180,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.69",
               "target": "anyhow"
             },
             {
@@ -13157,7 +13220,7 @@
               "target": "rpassword"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -13249,10 +13312,6 @@
               "target": "lazy_static"
             },
             {
-              "id": "log-panics 2.1.0",
-              "target": "log_panics"
-            },
-            {
               "id": "many-abci 0.1.0",
               "target": "build_script_build"
             },
@@ -13273,16 +13332,12 @@
               "target": "sha2"
             },
             {
-              "id": "signal-hook 0.3.14",
+              "id": "signal-hook 0.3.15",
               "target": "signal_hook"
             },
             {
               "id": "smol 1.3.0",
               "target": "smol"
-            },
-            {
-              "id": "syslog-tracing 0.1.0",
-              "target": "syslog_tracing"
             },
             {
               "id": "tendermint 0.24.0-pre.2",
@@ -13301,16 +13356,12 @@
               "target": "tendermint_rpc"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
               "id": "tracing 0.1.37",
               "target": "tracing"
-            },
-            {
-              "id": "tracing-subscriber 0.3.16",
-              "target": "tracing_subscriber"
             }
           ],
           "selects": {}
@@ -13319,7 +13370,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             }
           ],
@@ -13334,7 +13385,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.5.0",
+              "id": "vergen 7.5.1",
               "target": "vergen"
             }
           ],
@@ -13342,6 +13393,56 @@
         }
       },
       "license": "Apache-2.0"
+    },
+    "many-cli-helpers 0.1.0": {
+      "name": "many-cli-helpers",
+      "version": "0.1.0",
+      "repository": null,
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "many_cli_helpers",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "many_cli_helpers",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "clap 3.2.23",
+              "target": "clap"
+            },
+            {
+              "id": "log-panics 2.1.0",
+              "target": "log_panics"
+            },
+            {
+              "id": "syslog-tracing 0.1.0",
+              "target": "syslog_tracing"
+            },
+            {
+              "id": "tracing 0.1.37",
+              "target": "tracing"
+            },
+            {
+              "id": "tracing-subscriber 0.3.16",
+              "target": "tracing_subscriber"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": null
     },
     "many-client 0.1.0": {
       "name": "many-client",
@@ -13369,7 +13470,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.69",
               "target": "anyhow"
             },
             {
@@ -13405,7 +13506,7 @@
               "target": "ed25519_dalek"
             },
             {
-              "id": "fixed 1.22.1",
+              "id": "fixed 1.23.0",
               "target": "fixed"
             },
             {
@@ -13469,7 +13570,7 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -13483,7 +13584,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             },
             {
@@ -13520,7 +13621,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -13678,7 +13779,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "proptest 1.0.0",
+              "id": "proptest 1.1.0",
               "target": "proptest"
             },
             {
@@ -13807,7 +13908,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "proptest 1.0.0",
+              "id": "proptest 1.1.0",
               "target": "proptest"
             },
             {
@@ -13955,7 +14056,7 @@
               "target": "serde_cbor"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -14051,10 +14152,6 @@
               "target": "lazy_static"
             },
             {
-              "id": "log-panics 2.1.0",
-              "target": "log_panics"
-            },
-            {
               "id": "many-kvstore 0.1.0",
               "target": "build_script_build"
             },
@@ -14075,7 +14172,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -14083,7 +14180,7 @@
               "target": "sha3"
             },
             {
-              "id": "signal-hook 0.3.14",
+              "id": "signal-hook 0.3.15",
               "target": "signal_hook"
             },
             {
@@ -14095,20 +14192,12 @@
               "target": "strum"
             },
             {
-              "id": "syslog-tracing 0.1.0",
-              "target": "syslog_tracing"
-            },
-            {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
               "id": "tracing 0.1.37",
               "target": "tracing"
-            },
-            {
-              "id": "tracing-subscriber 0.3.16",
-              "target": "tracing_subscriber"
             }
           ],
           "selects": {}
@@ -14130,7 +14219,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             }
           ],
@@ -14145,7 +14234,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.5.0",
+              "id": "vergen 7.5.1",
               "target": "vergen"
             }
           ],
@@ -14211,7 +14300,7 @@
               "target": "coset"
             },
             {
-              "id": "fixed 1.22.1",
+              "id": "fixed 1.23.0",
               "target": "fixed"
             },
             {
@@ -14229,10 +14318,6 @@
             {
               "id": "linkme 0.3.7",
               "target": "linkme"
-            },
-            {
-              "id": "log-panics 2.1.0",
-              "target": "log_panics"
             },
             {
               "id": "many-ledger 0.1.0",
@@ -14263,7 +14348,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -14271,7 +14356,7 @@
               "target": "sha3"
             },
             {
-              "id": "signal-hook 0.3.14",
+              "id": "signal-hook 0.3.15",
               "target": "signal_hook"
             },
             {
@@ -14283,20 +14368,12 @@
               "target": "strum"
             },
             {
-              "id": "syslog-tracing 0.1.0",
-              "target": "syslog_tracing"
-            },
-            {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
               "id": "tracing 0.1.37",
               "target": "tracing"
-            },
-            {
-              "id": "tracing-subscriber 0.3.16",
-              "target": "tracing_subscriber"
             },
             {
               "id": "typenum 1.16.0",
@@ -14320,7 +14397,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proptest 1.0.0",
+              "id": "proptest 1.1.0",
               "target": "proptest"
             },
             {
@@ -14334,7 +14411,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             }
           ],
@@ -14349,7 +14426,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.5.0",
+              "id": "vergen 7.5.1",
               "target": "vergen"
             }
           ],
@@ -14443,11 +14520,11 @@
               "target": "once_cell"
             },
             {
-              "id": "proptest 1.0.0",
+              "id": "proptest 1.1.0",
               "target": "proptest"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -14493,7 +14570,7 @@
               "target": "inflections"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -14551,7 +14628,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -14635,15 +14712,15 @@
               "target": "cucumber"
             },
             {
-              "id": "futures 0.3.25",
+              "id": "futures 0.3.26",
               "target": "futures"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             }
           ],
@@ -14653,7 +14730,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             }
           ],
@@ -14734,7 +14811,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proptest 1.0.0",
+              "id": "proptest 1.1.0",
               "target": "proptest"
             },
             {
@@ -14748,7 +14825,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             },
             {
@@ -14817,7 +14894,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -14846,7 +14923,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proptest 1.0.0",
+              "id": "proptest 1.1.0",
               "target": "proptest"
             }
           ],
@@ -14893,7 +14970,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.69",
               "target": "anyhow"
             },
             {
@@ -14937,7 +15014,7 @@
               "target": "ed25519_dalek"
             },
             {
-              "id": "fixed 1.22.1",
+              "id": "fixed 1.23.0",
               "target": "fixed"
             },
             {
@@ -14989,7 +15066,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -15017,7 +15094,7 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -15030,7 +15107,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "proptest 1.0.0",
+              "id": "proptest 1.1.0",
               "target": "proptest"
             },
             {
@@ -15048,7 +15125,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             },
             {
@@ -15101,7 +15178,7 @@
               "target": "coset"
             },
             {
-              "id": "fixed 1.22.1",
+              "id": "fixed 1.23.0",
               "target": "fixed"
             },
             {
@@ -15121,7 +15198,7 @@
               "target": "num_traits"
             },
             {
-              "id": "proptest 1.0.0",
+              "id": "proptest 1.1.0",
               "target": "proptest"
             },
             {
@@ -15580,7 +15657,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -15839,7 +15916,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -15910,7 +15987,7 @@
                 "target": "libc"
               },
               {
-                "id": "security-framework 2.8.1",
+                "id": "security-framework 2.8.2",
                 "target": "security_framework"
               },
               {
@@ -16485,7 +16562,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -16689,10 +16766,15 @@
         "crate_features": [
           "default",
           "i128",
+          "libm",
           "std"
         ],
         "deps": {
           "common": [
+            {
+              "id": "libm 0.2.6",
+              "target": "libm"
+            },
             {
               "id": "num-traits 0.2.15",
               "target": "build_script_build"
@@ -16845,7 +16927,7 @@
               "target": "proc_macro_crate"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -17052,7 +17134,7 @@
         "deps": {
           "common": [
             {
-              "id": "parking_lot_core 0.9.6",
+              "id": "parking_lot_core 0.9.7",
               "target": "parking_lot_core"
             }
           ],
@@ -17221,7 +17303,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -17331,7 +17413,7 @@
               "target": "autocfg"
             },
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             },
             {
@@ -17541,7 +17623,7 @@
               "target": "lock_api"
             },
             {
-              "id": "parking_lot_core 0.9.6",
+              "id": "parking_lot_core 0.9.7",
               "target": "parking_lot_core"
             }
           ],
@@ -17552,13 +17634,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "parking_lot_core 0.9.6": {
+    "parking_lot_core 0.9.7": {
       "name": "parking_lot_core",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.6/download",
-          "sha256": "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.7/download",
+          "sha256": "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
         }
       },
       "targets": [
@@ -17593,7 +17675,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "parking_lot_core 0.9.6",
+              "id": "parking_lot_core 0.9.7",
               "target": "build_script_build"
             },
             {
@@ -17616,14 +17698,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.42.0",
+                "id": "windows-sys 0.45.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.9.6"
+        "version": "0.9.7"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -17921,7 +18003,7 @@
               "target": "peg_runtime"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -17968,7 +18050,7 @@
               "target": "peg_runtime"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -18161,13 +18243,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "pest 2.5.4": {
+    "pest 2.5.5": {
       "name": "pest",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest/2.5.4/download",
-          "sha256": "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
+          "url": "https://crates.io/api/v1/crates/pest/2.5.5/download",
+          "sha256": "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
         }
       },
       "targets": [
@@ -18205,17 +18287,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.5.4"
+        "version": "2.5.5"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_derive 2.5.4": {
+    "pest_derive 2.5.5": {
       "name": "pest_derive",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_derive/2.5.4/download",
-          "sha256": "8bf026e2d0581559db66d837fe5242320f525d85c76283c61f4d51a1238d65ea"
+          "url": "https://crates.io/api/v1/crates/pest_derive/2.5.5/download",
+          "sha256": "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
         }
       },
       "targets": [
@@ -18241,28 +18323,28 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.5.4",
+              "id": "pest 2.5.5",
               "target": "pest"
             },
             {
-              "id": "pest_generator 2.5.4",
+              "id": "pest_generator 2.5.5",
               "target": "pest_generator"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.5.4"
+        "version": "2.5.5"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_generator 2.5.4": {
+    "pest_generator 2.5.5": {
       "name": "pest_generator",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_generator/2.5.4/download",
-          "sha256": "2b27bd18aa01d91c8ed2b61ea23406a676b42d82609c6e2581fba42f0c15f17f"
+          "url": "https://crates.io/api/v1/crates/pest_generator/2.5.5/download",
+          "sha256": "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
         }
       },
       "targets": [
@@ -18287,15 +18369,15 @@
         "deps": {
           "common": [
             {
-              "id": "pest 2.5.4",
+              "id": "pest 2.5.5",
               "target": "pest"
             },
             {
-              "id": "pest_meta 2.5.4",
+              "id": "pest_meta 2.5.5",
               "target": "pest_meta"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -18310,17 +18392,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.5.4"
+        "version": "2.5.5"
       },
       "license": "MIT/Apache-2.0"
     },
-    "pest_meta 2.5.4": {
+    "pest_meta 2.5.5": {
       "name": "pest_meta",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pest_meta/2.5.4/download",
-          "sha256": "9f02b677c1859756359fc9983c2e56a0237f18624a3789528804406b7e915e5d"
+          "url": "https://crates.io/api/v1/crates/pest_meta/2.5.5/download",
+          "sha256": "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
         }
       },
       "targets": [
@@ -18346,14 +18428,14 @@
               "target": "once_cell"
             },
             {
-              "id": "pest 2.5.4",
+              "id": "pest 2.5.5",
               "target": "pest"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.5.4"
+        "version": "2.5.5"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -18424,7 +18506,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -19027,7 +19109,7 @@
               "target": "once_cell"
             },
             {
-              "id": "toml_edit 0.18.0",
+              "id": "toml_edit 0.18.1",
               "target": "toml_edit"
             }
           ],
@@ -19084,7 +19166,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -19167,7 +19249,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -19196,13 +19278,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.50": {
+    "proc-macro2 1.0.51": {
       "name": "proc-macro2",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.50/download",
-          "sha256": "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.51/download",
+          "sha256": "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
         }
       },
       "targets": [
@@ -19237,7 +19319,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "build_script_build"
             },
             {
@@ -19248,7 +19330,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.50"
+        "version": "1.0.51"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -19257,13 +19339,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proptest 1.0.0": {
+    "proptest 1.1.0": {
       "name": "proptest",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proptest/1.0.0/download",
-          "sha256": "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+          "url": "https://crates.io/api/v1/crates/proptest/1.1.0/download",
+          "sha256": "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
         }
       },
       "targets": [
@@ -19344,12 +19426,16 @@
             {
               "id": "tempfile 3.3.0",
               "target": "tempfile"
+            },
+            {
+              "id": "unarray 0.1.4",
+              "target": "unarray"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.0"
+        "version": "1.1.0"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -19384,7 +19470,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             }
           ],
@@ -19432,7 +19518,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.69",
               "target": "anyhow"
             },
             {
@@ -19440,7 +19526,7 @@
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -19487,7 +19573,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -19603,7 +19689,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -20240,15 +20326,15 @@
               "target": "base64"
             },
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-util 0.3.25",
+              "id": "futures-util 0.3.26",
               "target": "futures_util"
             },
             {
@@ -20275,7 +20361,7 @@
           "selects": {
             "cfg(not(target_arch = \"wasm32\"))": [
               {
-                "id": "encoding_rs 0.8.31",
+                "id": "encoding_rs 0.8.32",
                 "target": "encoding_rs"
               },
               {
@@ -20287,7 +20373,7 @@
                 "target": "http_body"
               },
               {
-                "id": "hyper 0.14.23",
+                "id": "hyper 0.14.24",
                 "target": "hyper"
               },
               {
@@ -20324,33 +20410,33 @@
                 "target": "pin_project_lite"
               },
               {
-                "id": "tokio 1.24.2",
+                "id": "tokio 1.25.0",
                 "target": "tokio"
               },
               {
-                "id": "tokio-native-tls 0.3.0",
+                "id": "tokio-native-tls 0.3.1",
                 "target": "tokio_native_tls"
               }
             ],
             "cfg(target_arch = \"wasm32\")": [
               {
-                "id": "js-sys 0.3.60",
+                "id": "js-sys 0.3.61",
                 "target": "js_sys"
               },
               {
-                "id": "serde_json 1.0.91",
+                "id": "serde_json 1.0.93",
                 "target": "serde_json"
               },
               {
-                "id": "wasm-bindgen 0.2.83",
+                "id": "wasm-bindgen 0.2.84",
                 "target": "wasm_bindgen"
               },
               {
-                "id": "wasm-bindgen-futures 0.4.33",
+                "id": "wasm-bindgen-futures 0.4.34",
                 "target": "wasm_bindgen_futures"
               },
               {
-                "id": "web-sys 0.3.60",
+                "id": "web-sys 0.3.61",
                 "target": "web_sys"
               }
             ],
@@ -20421,7 +20507,7 @@
           "selects": {
             "cfg(all(target_arch = \"wasm32\", target_vendor = \"unknown\", target_os = \"unknown\", target_env = \"\"))": [
               {
-                "id": "web-sys 0.3.60",
+                "id": "web-sys 0.3.61",
                 "target": "web_sys"
               }
             ],
@@ -20465,7 +20551,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             }
           ],
@@ -20507,7 +20593,7 @@
               "target": "libc"
             },
             {
-              "id": "librocksdb-sys 0.8.0+7.4.4",
+              "id": "librocksdb-sys 0.8.3+7.4.4",
               "target": "librocksdb_sys"
             }
           ],
@@ -20597,7 +20683,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             }
           ],
@@ -20793,13 +20879,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "rustix 0.36.7": {
+    "rustix 0.36.8": {
       "name": "rustix",
-      "version": "0.36.7",
+      "version": "0.36.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustix/0.36.7/download",
-          "sha256": "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+          "url": "https://crates.io/api/v1/crates/rustix/0.36.8/download",
+          "sha256": "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
         }
       },
       "targets": [
@@ -20842,11 +20928,11 @@
               "target": "bitflags"
             },
             {
-              "id": "io-lifetimes 1.0.4",
+              "id": "io-lifetimes 1.0.5",
               "target": "io_lifetimes"
             },
             {
-              "id": "rustix 0.36.7",
+              "id": "rustix 0.36.8",
               "target": "build_script_build"
             }
           ],
@@ -20880,14 +20966,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.42.0",
+                "id": "windows-sys 0.45.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.36.7"
+        "version": "0.36.8"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -21001,7 +21087,7 @@
             ],
             "cfg(target_os = \"macos\")": [
               {
-                "id": "security-framework 2.8.1",
+                "id": "security-framework 2.8.2",
                 "target": "security_framework"
               }
             ],
@@ -21434,7 +21520,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -21485,7 +21571,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -21504,13 +21590,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "security-framework 2.8.1": {
+    "security-framework 2.8.2": {
       "name": "security-framework",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/security-framework/2.8.1/download",
-          "sha256": "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
+          "url": "https://crates.io/api/v1/crates/security-framework/2.8.2/download",
+          "sha256": "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
         }
       },
       "targets": [
@@ -21559,7 +21645,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.8.1"
+        "version": "2.8.2"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -21766,13 +21852,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_bytes 0.11.8": {
+    "serde_bytes 0.11.9": {
       "name": "serde_bytes",
-      "version": "0.11.8",
+      "version": "0.11.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_bytes/0.11.8/download",
-          "sha256": "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+          "url": "https://crates.io/api/v1/crates/serde_bytes/0.11.9/download",
+          "sha256": "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
         }
       },
       "targets": [
@@ -21806,7 +21892,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.11.8"
+        "version": "0.11.9"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -21944,7 +22030,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -21972,13 +22058,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.91": {
+    "serde_json 1.0.93": {
       "name": "serde_json",
-      "version": "1.0.91",
+      "version": "1.0.93",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_json/1.0.91/download",
-          "sha256": "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+          "url": "https://crates.io/api/v1/crates/serde_json/1.0.93/download",
+          "sha256": "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
         }
       },
       "targets": [
@@ -22026,14 +22112,14 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.91"
+        "version": "1.0.93"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -22070,7 +22156,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -22174,7 +22260,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -22588,13 +22674,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "signal-hook 0.3.14": {
+    "signal-hook 0.3.15": {
       "name": "signal-hook",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/signal-hook/0.3.14/download",
-          "sha256": "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+          "url": "https://crates.io/api/v1/crates/signal-hook/0.3.15/download",
+          "sha256": "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
         }
       },
       "targets": [
@@ -22634,18 +22720,18 @@
               "target": "libc"
             },
             {
-              "id": "signal-hook 0.3.14",
+              "id": "signal-hook 0.3.15",
               "target": "build_script_build"
             },
             {
-              "id": "signal-hook-registry 1.4.0",
+              "id": "signal-hook-registry 1.4.1",
               "target": "signal_hook_registry"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.14"
+        "version": "0.3.15"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -22654,13 +22740,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "signal-hook-registry 1.4.0": {
+    "signal-hook-registry 1.4.1": {
       "name": "signal-hook-registry",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/signal-hook-registry/1.4.0/download",
-          "sha256": "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+          "url": "https://crates.io/api/v1/crates/signal-hook-registry/1.4.1/download",
+          "sha256": "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
         }
       },
       "targets": [
@@ -22689,7 +22775,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.4.0"
+        "version": "1.4.1"
       },
       "license": "Apache-2.0/MIT"
     },
@@ -23323,11 +23409,11 @@
         "deps": {
           "common": [
             {
-              "id": "heck 0.4.0",
+              "id": "heck 0.4.1",
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -23515,7 +23601,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -23575,7 +23661,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -23721,7 +23807,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -23864,13 +23950,13 @@
       },
       "license": "MIT"
     },
-    "target-lexicon 0.12.5": {
+    "target-lexicon 0.12.6": {
       "name": "target-lexicon",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/target-lexicon/0.12.5/download",
-          "sha256": "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+          "url": "https://crates.io/api/v1/crates/target-lexicon/0.12.6/download",
+          "sha256": "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
         }
       },
       "targets": [
@@ -23904,14 +23990,14 @@
         "deps": {
           "common": [
             {
-              "id": "target-lexicon 0.12.5",
+              "id": "target-lexicon 0.12.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.12.5"
+        "version": "0.12.6"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -24019,7 +24105,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -24035,7 +24121,7 @@
               "target": "flex_error"
             },
             {
-              "id": "futures 0.3.25",
+              "id": "futures 0.3.26",
               "target": "futures"
             },
             {
@@ -24059,11 +24145,11 @@
               "target": "serde"
             },
             {
-              "id": "serde_bytes 0.11.8",
+              "id": "serde_bytes 0.11.9",
               "target": "serde_bytes"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -24101,7 +24187,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             },
             {
@@ -24146,7 +24232,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -24209,7 +24295,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -24260,7 +24346,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -24284,7 +24370,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_bytes 0.11.8",
+              "id": "serde_bytes 0.11.9",
               "target": "serde_bytes"
             },
             {
@@ -24352,7 +24438,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -24360,7 +24446,7 @@
               "target": "flex_error"
             },
             {
-              "id": "futures 0.3.25",
+              "id": "futures 0.3.26",
               "target": "futures"
             },
             {
@@ -24372,7 +24458,7 @@
               "target": "http"
             },
             {
-              "id": "hyper 0.14.23",
+              "id": "hyper 0.14.24",
               "target": "hyper"
             },
             {
@@ -24396,11 +24482,11 @@
               "target": "serde"
             },
             {
-              "id": "serde_bytes 0.11.8",
+              "id": "serde_bytes 0.11.9",
               "target": "serde_bytes"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -24432,7 +24518,7 @@
               "target": "time"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -24458,7 +24544,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.63",
+              "id": "async-trait 0.1.64",
               "target": "async_trait"
             }
           ],
@@ -24539,7 +24625,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "rustix 0.36.7",
+                "id": "rustix 0.36.8",
                 "target": "rustix"
               }
             ],
@@ -24807,7 +24893,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -24826,13 +24912,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "thread_local 1.1.4": {
+    "thread_local 1.1.7": {
       "name": "thread_local",
-      "version": "1.1.4",
+      "version": "1.1.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thread_local/1.1.4/download",
-          "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+          "url": "https://crates.io/api/v1/crates/thread_local/1.1.7/download",
+          "sha256": "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
         }
       },
       "targets": [
@@ -24854,16 +24940,20 @@
         "deps": {
           "common": [
             {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
               "id": "once_cell 1.17.0",
               "target": "once_cell"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "1.1.4"
+        "edition": "2021",
+        "version": "1.1.7"
       },
-      "license": "Apache-2.0/MIT"
+      "license": "MIT OR Apache-2.0"
     },
     "time 0.3.17": {
       "name": "time",
@@ -25093,7 +25183,7 @@
         "deps": {
           "common": [
             {
-              "id": "tinyvec_macros 0.1.0",
+              "id": "tinyvec_macros 0.1.1",
               "target": "tinyvec_macros"
             }
           ],
@@ -25104,13 +25194,13 @@
       },
       "license": "Zlib OR Apache-2.0 OR MIT"
     },
-    "tinyvec_macros 0.1.0": {
+    "tinyvec_macros 0.1.1": {
       "name": "tinyvec_macros",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tinyvec_macros/0.1.0/download",
-          "sha256": "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+          "url": "https://crates.io/api/v1/crates/tinyvec_macros/0.1.1/download",
+          "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
         }
       },
       "targets": [
@@ -25130,17 +25220,17 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.1.0"
+        "version": "0.1.1"
       },
       "license": "MIT OR Apache-2.0 OR Zlib"
     },
-    "tokio 1.24.2": {
+    "tokio 1.25.0": {
       "name": "tokio",
-      "version": "1.24.2",
+      "version": "1.25.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.24.2/download",
-          "sha256": "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+          "url": "https://crates.io/api/v1/crates/tokio/1.25.0/download",
+          "sha256": "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
         }
       },
       "targets": [
@@ -25196,7 +25286,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
@@ -25220,7 +25310,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "build_script_build"
             }
           ],
@@ -25243,7 +25333,7 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.0",
+                "id": "signal-hook-registry 1.4.1",
                 "target": "signal_hook_registry"
               }
             ],
@@ -25265,7 +25355,7 @@
           ],
           "selects": {}
         },
-        "version": "1.24.2"
+        "version": "1.25.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -25311,7 +25401,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -25330,13 +25420,13 @@
       },
       "license": "MIT"
     },
-    "tokio-native-tls 0.3.0": {
+    "tokio-native-tls 0.3.1": {
       "name": "tokio-native-tls",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-native-tls/0.3.0/download",
-          "sha256": "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+          "url": "https://crates.io/api/v1/crates/tokio-native-tls/0.3.1/download",
+          "sha256": "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
         }
       },
       "targets": [
@@ -25362,14 +25452,14 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.0"
+        "version": "0.3.1"
       },
       "license": "MIT"
     },
@@ -25405,7 +25495,7 @@
               "target": "rustls"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -25420,13 +25510,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "tokio-util 0.7.4": {
+    "tokio-util 0.7.7": {
       "name": "tokio-util",
-      "version": "0.7.4",
+      "version": "0.7.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-util/0.7.4/download",
-          "sha256": "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+          "url": "https://crates.io/api/v1/crates/tokio-util/0.7.7/download",
+          "sha256": "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
         }
       },
       "targets": [
@@ -25453,15 +25543,15 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.3.0",
+              "id": "bytes 1.4.0",
               "target": "bytes"
             },
             {
-              "id": "futures-core 0.3.25",
+              "id": "futures-core 0.3.26",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.25",
+              "id": "futures-sink 0.3.26",
               "target": "futures_sink"
             },
             {
@@ -25469,7 +25559,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.24.2",
+              "id": "tokio 1.25.0",
               "target": "tokio"
             },
             {
@@ -25480,7 +25570,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.7.4"
+        "version": "0.7.7"
       },
       "license": "MIT"
     },
@@ -25556,13 +25646,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "toml_edit 0.18.0": {
+    "toml_edit 0.18.1": {
       "name": "toml_edit",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/toml_edit/0.18.0/download",
-          "sha256": "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+          "url": "https://crates.io/api/v1/crates/toml_edit/0.18.1/download",
+          "sha256": "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
         }
       },
       "targets": [
@@ -25602,7 +25692,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.18.0"
+        "version": "0.18.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -25726,7 +25816,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -25901,7 +25991,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thread_local 1.1.4",
+              "id": "thread_local 1.1.7",
               "target": "thread_local"
             },
             {
@@ -25978,7 +26068,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -26025,7 +26115,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -26185,7 +26275,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -26234,6 +26324,36 @@
         ],
         "edition": "2018",
         "version": "0.1.5"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "unarray 0.1.4": {
+      "name": "unarray",
+      "version": "0.1.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/unarray/0.1.4/download",
+          "sha256": "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "unarray",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "unarray",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.1.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -26473,13 +26593,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "unicode-segmentation 1.10.0": {
+    "unicode-segmentation 1.10.1": {
       "name": "unicode-segmentation",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-segmentation/1.10.0/download",
-          "sha256": "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+          "url": "https://crates.io/api/v1/crates/unicode-segmentation/1.10.1/download",
+          "sha256": "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
         }
       },
       "targets": [
@@ -26499,7 +26619,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.10.0"
+        "version": "1.10.1"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -26684,13 +26804,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "uuid 1.2.2": {
+    "uuid 1.3.0": {
       "name": "uuid",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/uuid/1.2.2/download",
-          "sha256": "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+          "url": "https://crates.io/api/v1/crates/uuid/1.3.0/download",
+          "sha256": "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
         }
       },
       "targets": [
@@ -26731,7 +26851,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.2.2"
+        "version": "1.3.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -26852,13 +26972,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "vergen 7.5.0": {
+    "vergen 7.5.1": {
       "name": "vergen",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/vergen/7.5.0/download",
-          "sha256": "571b69f690c855821462709b6f41d42ceccc316fbd17b60bd06d06928cfe6a99"
+          "url": "https://crates.io/api/v1/crates/vergen/7.5.1/download",
+          "sha256": "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
         }
       },
       "targets": [
@@ -26901,7 +27021,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.69",
               "target": "anyhow"
             },
             {
@@ -26909,11 +27029,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "enum-iterator 1.2.0",
+              "id": "enum-iterator 1.3.0",
               "target": "enum_iterator"
             },
             {
-              "id": "git2 0.15.0",
+              "id": "git2 0.16.1",
               "target": "git2"
             },
             {
@@ -26933,7 +27053,7 @@
               "target": "time"
             },
             {
-              "id": "vergen 7.5.0",
+              "id": "vergen 7.5.1",
               "target": "build_script_build"
             }
           ],
@@ -26949,7 +27069,7 @@
           ],
           "selects": {}
         },
-        "version": "7.5.0"
+        "version": "7.5.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -26958,7 +27078,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.69",
               "target": "anyhow"
             },
             {
@@ -27242,13 +27362,13 @@
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
-    "wasm-bindgen 0.2.83": {
+    "wasm-bindgen 0.2.84": {
       "name": "wasm-bindgen",
-      "version": "0.2.83",
+      "version": "0.2.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen/0.2.83/download",
-          "sha256": "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen/0.2.84/download",
+          "sha256": "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
         }
       },
       "targets": [
@@ -27288,7 +27408,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "wasm-bindgen 0.2.83",
+              "id": "wasm-bindgen 0.2.84",
               "target": "build_script_build"
             }
           ],
@@ -27298,13 +27418,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasm-bindgen-macro 0.2.83",
+              "id": "wasm-bindgen-macro 0.2.84",
               "target": "wasm_bindgen_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.2.83"
+        "version": "0.2.84"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -27313,13 +27433,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-backend 0.2.83": {
+    "wasm-bindgen-backend 0.2.84": {
       "name": "wasm-bindgen-backend",
-      "version": "0.2.83",
+      "version": "0.2.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.83/download",
-          "sha256": "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.84/download",
+          "sha256": "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
         }
       },
       "targets": [
@@ -27356,7 +27476,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -27368,24 +27488,24 @@
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.83",
+              "id": "wasm-bindgen-shared 0.2.84",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.83"
+        "version": "0.2.84"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-futures 0.4.33": {
+    "wasm-bindgen-futures 0.4.34": {
       "name": "wasm-bindgen-futures",
-      "version": "0.4.33",
+      "version": "0.4.34",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-futures/0.4.33/download",
-          "sha256": "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-futures/0.4.34/download",
+          "sha256": "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
         }
       },
       "targets": [
@@ -27411,35 +27531,35 @@
               "target": "cfg_if"
             },
             {
-              "id": "js-sys 0.3.60",
+              "id": "js-sys 0.3.61",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.83",
+              "id": "wasm-bindgen 0.2.84",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {
             "cfg(target_feature = \"atomics\")": [
               {
-                "id": "web-sys 0.3.60",
+                "id": "web-sys 0.3.61",
                 "target": "web_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.4.33"
+        "version": "0.4.34"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-macro 0.2.83": {
+    "wasm-bindgen-macro 0.2.84": {
       "name": "wasm-bindgen-macro",
-      "version": "0.2.83",
+      "version": "0.2.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.83/download",
-          "sha256": "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.84/download",
+          "sha256": "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
         }
       },
       "targets": [
@@ -27468,24 +27588,24 @@
               "target": "quote"
             },
             {
-              "id": "wasm-bindgen-macro-support 0.2.83",
+              "id": "wasm-bindgen-macro-support 0.2.84",
               "target": "wasm_bindgen_macro_support"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.83"
+        "version": "0.2.84"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-macro-support 0.2.83": {
+    "wasm-bindgen-macro-support 0.2.84": {
       "name": "wasm-bindgen-macro-support",
-      "version": "0.2.83",
+      "version": "0.2.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.83/download",
-          "sha256": "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.84/download",
+          "sha256": "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
         }
       },
       "targets": [
@@ -27510,7 +27630,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -27522,28 +27642,28 @@
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-backend 0.2.83",
+              "id": "wasm-bindgen-backend 0.2.84",
               "target": "wasm_bindgen_backend"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.83",
+              "id": "wasm-bindgen-shared 0.2.84",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.83"
+        "version": "0.2.84"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-shared 0.2.83": {
+    "wasm-bindgen-shared 0.2.84": {
       "name": "wasm-bindgen-shared",
-      "version": "0.2.83",
+      "version": "0.2.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.83/download",
-          "sha256": "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.84/download",
+          "sha256": "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
         }
       },
       "targets": [
@@ -27574,14 +27694,14 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen-shared 0.2.83",
+              "id": "wasm-bindgen-shared 0.2.84",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.83"
+        "version": "0.2.84"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -27591,13 +27711,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "web-sys 0.3.60": {
+    "web-sys 0.3.61": {
       "name": "web-sys",
-      "version": "0.3.60",
+      "version": "0.3.61",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/web-sys/0.3.60/download",
-          "sha256": "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+          "url": "https://crates.io/api/v1/crates/web-sys/0.3.61/download",
+          "sha256": "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
         }
       },
       "targets": [
@@ -27640,18 +27760,18 @@
         "deps": {
           "common": [
             {
-              "id": "js-sys 0.3.60",
+              "id": "js-sys 0.3.61",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.83",
+              "id": "wasm-bindgen 0.2.84",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.60"
+        "version": "0.3.61"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -27724,7 +27844,7 @@
               "alias": "serde_cbor"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -27736,7 +27856,7 @@
               "target": "url"
             },
             {
-              "id": "uuid 1.2.2",
+              "id": "uuid 1.3.0",
               "target": "uuid"
             },
             {
@@ -27795,7 +27915,7 @@
               "target": "url"
             },
             {
-              "id": "uuid 1.2.2",
+              "id": "uuid 1.3.0",
               "target": "uuid"
             },
             {
@@ -27878,7 +27998,7 @@
               "alias": "serde_cbor"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -27894,7 +28014,7 @@
               "target": "url"
             },
             {
-              "id": "uuid 1.2.2",
+              "id": "uuid 1.3.0",
               "target": "uuid"
             },
             {
@@ -27949,7 +28069,7 @@
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.93",
               "target": "serde_json"
             },
             {
@@ -28107,7 +28227,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             }
           ],
@@ -28144,7 +28264,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             },
             {
@@ -28464,8 +28584,6 @@
         "crate_features": [
           "Win32",
           "Win32_Foundation",
-          "Win32_NetworkManagement",
-          "Win32_NetworkManagement_IpHelper",
           "Win32_Networking",
           "Win32_Networking_WinSock",
           "Win32_Security",
@@ -28479,7 +28597,6 @@
           "Win32_System",
           "Win32_System_Console",
           "Win32_System_IO",
-          "Win32_System_LibraryLoader",
           "Win32_System_Memory",
           "Win32_System_Pipes",
           "Win32_System_SystemServices",
@@ -28569,6 +28686,173 @@
         },
         "edition": "2018",
         "version": "0.42.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows-sys 0.45.0": {
+      "name": "windows-sys",
+      "version": "0.45.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows-sys/0.45.0/download",
+          "sha256": "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "Win32",
+          "Win32_Foundation",
+          "Win32_NetworkManagement",
+          "Win32_NetworkManagement_IpHelper",
+          "Win32_Networking",
+          "Win32_Networking_WinSock",
+          "Win32_Security",
+          "Win32_Storage",
+          "Win32_Storage_FileSystem",
+          "Win32_System",
+          "Win32_System_Console",
+          "Win32_System_IO",
+          "Win32_System_LibraryLoader",
+          "Win32_System_SystemServices",
+          "Win32_System_Threading",
+          "Win32_System_WindowsProgramming",
+          "default"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(not(windows_raw_dylib))": [
+              {
+                "id": "windows-targets 0.42.1",
+                "target": "windows_targets"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.45.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows-targets 0.42.1": {
+      "name": "windows-targets",
+      "version": "0.42.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows-targets/0.42.1/download",
+          "sha256": "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_targets",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_targets",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-gnullvm": [
+              {
+                "id": "windows_aarch64_gnullvm 0.42.1",
+                "target": "windows_aarch64_gnullvm"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "windows_aarch64_msvc 0.42.1",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "aarch64-uwp-windows-msvc": [
+              {
+                "id": "windows_aarch64_msvc 0.42.1",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "i686-pc-windows-gnu": [
+              {
+                "id": "windows_i686_gnu 0.42.1",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "windows_i686_msvc 0.42.1",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "i686-uwp-windows-gnu": [
+              {
+                "id": "windows_i686_gnu 0.42.1",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "i686-uwp-windows-msvc": [
+              {
+                "id": "windows_i686_msvc 0.42.1",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "x86_64-pc-windows-gnu": [
+              {
+                "id": "windows_x86_64_gnu 0.42.1",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "x86_64-pc-windows-gnullvm": [
+              {
+                "id": "windows_x86_64_gnullvm 0.42.1",
+                "target": "windows_x86_64_gnullvm"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "windows_x86_64_msvc 0.42.1",
+                "target": "windows_x86_64_msvc"
+              }
+            ],
+            "x86_64-uwp-windows-gnu": [
+              {
+                "id": "windows_x86_64_gnu 0.42.1",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "x86_64-uwp-windows-msvc": [
+              {
+                "id": "windows_x86_64_msvc 0.42.1",
+                "target": "windows_x86_64_msvc"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.42.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -29149,7 +29433,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.50",
+              "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
             },
             {
@@ -29182,6 +29466,7 @@
     "ledger-db 0.1.0": "src/ledger-db",
     "many 0.1.0": "src/many",
     "many-abci 0.1.0": "src/many-abci",
+    "many-cli-helpers 0.1.0": "src/many-cli-helpers",
     "many-client 0.1.0": "src/many-client",
     "many-client-macros 0.1.0": "src/many-client-macros",
     "many-error 0.1.0": "src/many-error",
@@ -29644,6 +29929,34 @@
       "x86_64-apple-darwin",
       "x86_64-apple-ios",
       "x86_64-linux-android",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(not(windows_raw_dylib))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "riscv64gc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
+      "wasm32-unknown-unknown",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
     ],

--- a/src/kvstore/BUILD.bazel
+++ b/src/kvstore/BUILD.bazel
@@ -14,6 +14,7 @@ rust_binary(
         normal = True,
     ) + [
         "//src/many-client",
+        "//src/many-cli-helpers",
         "//src/many-error",
         "//src/many-identity",
         "//src/many-identity-dsa",

--- a/src/ledger/BUILD.bazel
+++ b/src/ledger/BUILD.bazel
@@ -13,6 +13,7 @@ rust_binary(
     deps = all_crate_deps(
         normal = True,
     ) + [
+        "//src/many-cli-helpers",
         "//src/many-client",
         "//src/many-error",
         "//src/many-identity",

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -23,10 +23,10 @@ humantime = "2.1.0"
 indicatif = "0.16.2"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
-log-panics = { version = "2", features = ["with-backtrace"]}
 mime_guess = "2.0.4"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
 num-bigint = "0.4.3"
+many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.0" }
 many-client = { path = "../many-client", version = "0.1.0" }
 many-error = { path = "../many-error", version = "0.1.0" }
 many-identity = { path = "../many-identity", version = "0.1.0", features = ["serde"] }
@@ -38,9 +38,6 @@ many-types = { path = "../many-types", version = "0.1.0" }
 regex = "1.5.4"
 ring = "0.16.20"
 rpassword = "6.0"
-#serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
-syslog-tracing = "0.1"
 tracing = "0.1.29"
-tracing-subscriber = "0.3"
 tokio = { version = "1.24.1", features = [ "full" ] }

--- a/src/many-abci/BUILD.bazel
+++ b/src/many-abci/BUILD.bazel
@@ -23,6 +23,7 @@ rust_binary(
     ) + [
         ":build_script",
         "//src/many-client",
+        "//src/many-cli-helpers",
         "//src/many-error",
         "//src/many-identity",
         "//src/many-identity-dsa",
@@ -46,6 +47,7 @@ rust_library(
         normal = True,
     ) + [
         "//src/many-client",
+        "//src/many-cli-helpers",
         "//src/many-error",
         "//src/many-identity",
         "//src/many-identity-dsa",

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -25,8 +25,8 @@ hex = "0.4.3"
 itertools = "0.10.5"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
-log-panics = { version = "2", features = ["with-backtrace"]}
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
+many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.0" }
 many-client = { path = "../many-client", version = "0.1.0" }
 many-error = { path = "../many-error", version = "0.1.0" }
 many-identity = { path = "../many-identity", version = "0.1.0" }
@@ -41,14 +41,12 @@ reqwest = "0.11.11"
 sha2 = "0.10.1"
 signal-hook = "0.3.13"
 smol = "1.2.5"
-syslog-tracing = "0.1.0"
 tendermint = "0.24.0-pre.2"
 tendermint-abci = "0.24.0-pre.2"
 tendermint-rpc = { version = "0.24.0-pre.2", features = [ "http-client" ] }
 tendermint-proto = "0.24.0-pre.2"
 tokio = { version = "1.24.1", features = [ "full" ] }
 tracing = "0.1.28"
-tracing-subscriber = "0.3"
 
 [build-dependencies]
 vergen = "7"

--- a/src/many-cli-helpers/BUILD.bazel
+++ b/src/many-cli-helpers/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = [
+    "//src:__subpackages__",
+])
+
+rust_library(
+    name = "many-cli-helpers",
+    srcs = glob(include = ["src/**/*.rs"]),
+    aliases = aliases(),
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+    ),
+    deps = all_crate_deps(
+        normal = True,
+    ),
+)

--- a/src/many-cli-helpers/Cargo.toml
+++ b/src/many-cli-helpers/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "many-cli-helpers"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "3.0", features = ["derive"] }
+log-panics = { version = "2", features = ["with-backtrace"]}
+syslog-tracing = "0.1.0"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"

--- a/src/many-cli-helpers/src/lib.rs
+++ b/src/many-cli-helpers/src/lib.rs
@@ -1,0 +1,79 @@
+use tracing::metadata::LevelFilter;
+use tracing_subscriber::fmt::Subscriber;
+
+#[derive(clap::ArgEnum, Clone, Debug)]
+enum LogStrategy {
+    Terminal,
+    Syslog,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct Verbosity {
+    /// Increase output logging verbosity to DEBUG level.
+    #[clap(
+        long,
+        short = 'v',
+        action = clap::ArgAction::Count,
+        global = true,
+    )]
+    verbose: u8,
+
+    /// Suppress all output logging. Can be used multiple times to suppress more.
+    #[clap(
+        long,
+        short = 'q',
+        action = clap::ArgAction::Count,
+        global = true,
+    )]
+    quiet: u8,
+}
+
+impl Verbosity {
+    pub fn level(&self) -> LevelFilter {
+        let verbose_level = 2 + (self.verbose as i8) - (self.quiet as i8);
+        match verbose_level {
+            i8::MIN..=-1 => LevelFilter::OFF,
+            0 => LevelFilter::ERROR,
+            1 => LevelFilter::WARN,
+            2 => LevelFilter::INFO,
+            3 => LevelFilter::DEBUG,
+            4..=i8::MAX => LevelFilter::TRACE,
+        }
+    }
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct CommonCliFlags {
+    #[clap(flatten)]
+    verbosity: Verbosity,
+
+    /// Use given logging strategy
+    #[clap(long, arg_enum, default_value_t = LogStrategy::Terminal)]
+    logmode: LogStrategy,
+}
+
+impl CommonCliFlags {
+    pub fn init_logging(&self) -> Result<(), String> {
+        let subscriber = Subscriber::builder().with_max_level(self.verbosity.level());
+
+        match self.logmode {
+            LogStrategy::Terminal => {
+                let subscriber = subscriber.with_writer(std::io::stderr);
+                subscriber.init();
+            }
+            LogStrategy::Syslog => {
+                let identity = std::ffi::CStr::from_bytes_with_nul(b"many-ledger\0")
+                    .map_err(|e| e.to_string())?;
+                let (options, facility) = Default::default();
+                let syslog = syslog_tracing::Syslog::new(identity, options, facility)
+                    .ok_or_else(|| "Could not create syslog logger.".to_string())?;
+
+                let subscriber = subscriber.with_ansi(false).with_writer(syslog);
+                subscriber.init();
+                log_panics::init();
+            }
+        };
+
+        Ok(())
+    }
+}

--- a/src/many-kvstore/BUILD.bazel
+++ b/src/many-kvstore/BUILD.bazel
@@ -22,6 +22,7 @@ rust_binary(
         normal = True,
     ) + [
         ":build_script",
+        "//src/many-cli-helpers",
         "//src/many-error",
         "//src/many-identity",
         "//src/many-identity-dsa",

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -25,9 +25,9 @@ hex = { version = "0.4.3", features = ["serde"] }
 itertools = "0.10.3"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
-log-panics = { version = "2", features = ["with-backtrace"]}
 num-bigint = "0.4.3"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
+many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.0" }
 many-error = { path = "../many-error", version = "0.1.0" }
 many-identity = { path = "../many-identity", version = "0.1.0", features = ["default", "serde"] }
 many-identity-dsa = { path = "../many-identity-dsa", version = "0.1.0", features = ["ed25519", "ecdsa"]  }
@@ -41,10 +41,8 @@ sha3 = "0.10.4"
 signal-hook = "0.3.13"
 simple_asn1 = "0.6.2"
 strum = "0.24.1"
-syslog-tracing = "0.1"
 tokio = { version = "1.24.1", features = [ "full" ] }
 tracing = "0.1.28"
-tracing-subscriber = "0.3"
 
 [dev-dependencies]
 once_cell = "1.14.0"

--- a/src/many-kvstore/src/main.rs
+++ b/src/many-kvstore/src/main.rs
@@ -11,7 +11,6 @@ use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use tracing::level_filters::LevelFilter;
 use tracing::{debug, info};
 
 mod error;
@@ -20,21 +19,10 @@ mod storage;
 
 use module::*;
 
-#[derive(clap::ArgEnum, Clone, Debug)]
-enum LogStrategy {
-    Terminal,
-    Syslog,
-}
-
 #[derive(Debug, Parser)]
 struct Opts {
-    /// Increase output logging verbosity to DEBUG level.
-    #[clap(short, long, parse(from_occurrences))]
-    verbose: i8,
-
-    /// Suppress all output logging. Can be used multiple times to suppress more.
-    #[clap(short, long, parse(from_occurrences))]
-    quiet: i8,
+    #[clap(flatten)]
+    common_flags: many_cli_helpers::CommonCliFlags,
 
     /// The location of a PEM file for the identity of this server.
     #[clap(long)]
@@ -61,10 +49,6 @@ struct Opts {
     #[clap(long, short)]
     clean: bool,
 
-    /// Use given logging strategy
-    #[clap(long, arg_enum, default_value_t = LogStrategy::Terminal)]
-    logmode: LogStrategy,
-
     /// Path to a JSON file containing an array of MANY addresses
     /// Only addresses from this array will be able to execute commands, e.g., send, put, ...
     /// Any addresses will be able to execute queries, e.g., balance, get, ...
@@ -74,45 +58,17 @@ struct Opts {
 
 fn main() {
     let Opts {
-        verbose,
-        quiet,
+        common_flags,
         pem,
         addr,
         abci,
         mut state,
         persistent,
         clean,
-        logmode,
         allow_addrs,
     } = Opts::parse();
 
-    let verbose_level = 2 + verbose - quiet;
-    let log_level = match verbose_level {
-        x if x > 3 => LevelFilter::TRACE,
-        3 => LevelFilter::DEBUG,
-        2 => LevelFilter::INFO,
-        1 => LevelFilter::WARN,
-        0 => LevelFilter::ERROR,
-        x if x < 0 => LevelFilter::OFF,
-        _ => unreachable!(),
-    };
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder().with_max_level(log_level);
-
-    match logmode {
-        LogStrategy::Terminal => {
-            let subscriber = subscriber.with_writer(std::io::stderr);
-            subscriber.init();
-        }
-        LogStrategy::Syslog => {
-            let identity = std::ffi::CStr::from_bytes_with_nul(b"many-kvstore\0").unwrap();
-            let (options, facility) = Default::default();
-            let syslog = syslog_tracing::Syslog::new(identity, options, facility).unwrap();
-
-            let subscriber = subscriber.with_ansi(false).with_writer(syslog);
-            subscriber.init();
-            log_panics::init();
-        }
-    };
+    common_flags.init_logging().unwrap();
 
     debug!("{:?}", Opts::parse());
     info!(

--- a/src/many-ledger/BUILD.bazel
+++ b/src/many-ledger/BUILD.bazel
@@ -24,6 +24,7 @@ rust_binary(
         normal = True,
     ) + [
         ":build_script",
+        "//src/many-cli-helpers",
         "//src/many-error",
         "//src/many-identity",
         "//src/many-identity-dsa",

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -29,10 +29,10 @@ hex = "0.4.3"
 itertools = "0.10.3"
 json5 = "0.4.1"
 linkme = { version = "0.3.5", features = ["used_linker"] }
-log-panics = { version = "2", features = ["with-backtrace"]}
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 minicbor = { version = "0.18.0", features = ["derive", "std"] }
+many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.0" }
 many-error = { path = "../many-error", version = "0.1.0" }
 many-identity = { path = "../many-identity", version = "0.1.0", features = ["default", "serde"] }
 many-identity-dsa = { path = "../many-identity-dsa", version = "0.1.0", features = ["ed25519", "ecdsa"]  }
@@ -49,10 +49,8 @@ sha3 = "0.9.1"
 signal-hook = "0.3.13"
 simple_asn1 = "0.6.2"
 strum = "0.24.1"
-syslog-tracing = "0.1"
-tracing = "0.1.28"
 tokio = { version = "1.24.1", features = [ "full" ] }
-tracing-subscriber = "0.3"
+tracing = "0.1.28"
 typenum = "1.15.0"
 typetag = "0.2.3"
 

--- a/src/many/BUILD.bazel
+++ b/src/many/BUILD.bazel
@@ -11,6 +11,7 @@ rust_binary(
     deps = all_crate_deps(
         normal = True,
     ) + [
+        "//src/many-cli-helpers",
         "//src/many-client",
         "//src/many-error",
         "//src/many-identity",

--- a/src/many/Cargo.toml
+++ b/src/many/Cargo.toml
@@ -13,6 +13,7 @@ name = "many"
 path = "src/main.rs"
 
 [dependencies]
+many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.0" }
 many-client = { path = "../many-client", version = "0.1.0" }
 many-error = { path = "../many-error", version = "0.1.0" }
 many-identity = { path = "../many-identity", version = "0.1.0", features = ["coset"] }


### PR DESCRIPTION
Simplifies a lot of duplicated code for CLI builders, and streamline our flags across CLI tools.