### PR TITLE
Add support for `bats_test_suite`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,7 +9,7 @@ build --flag_alias=disable_token_sender_check=//src/many-ledger:disable_token_se
 
 build:all-features --balance_testing --migration_testing --webauthn_testing --disable_token_sender_check
 
-run:bats-resiliency-ledger --balance_testing --migration_testing
+test:bats-resiliency-ledger --balance_testing --migration_testing
 
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
       - checkout
       - run:
           name: running tests
-          command: bazel run --config=remote-cache //tests/resiliency/kvstore:bats-resiliency-kvstore
+          command: bazel test --config=remote-cache //tests/resiliency/kvstore:bats-resiliency-kvstore
 
   ledger_resiliency_tests:
     executor: linux2204_machine
@@ -212,7 +212,7 @@ jobs:
       - checkout
       - run:
           name: running tests
-          command: bazel run --config=remote-cache --config=bats-resiliency-ledger //tests/resiliency/ledger:bats-resiliency-ledger
+          command: bazel test --config=remote-cache --config=bats-resiliency-ledger //tests/resiliency/ledger:bats-resiliency-ledger
 
   # Push a tag to GitHub
   tag:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -3,8 +3,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 ## RUST SECTION ##
 http_archive(
     name = "rules_rust",
-    sha256 = "d125fb75432dc3b20e9b5a19347b45ec607fabe75f98c6c4ba9badaab9c193ce",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.17.0/rules_rust-v0.17.0.tar.gz"],
+    sha256 = "2466e5b2514772e84f9009010797b9cd4b51c1e6445bbd5b5e24848d90e6fb2e",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.18.0/rules_rust-v0.18.0.tar.gz"],
 )
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")

--- a/rules.bzl
+++ b/rules.bzl
@@ -115,9 +115,6 @@ def bats_test_suite(name, srcs, **kwargs):
     tests = []
 
     for src in srcs:
-        if not src.endswith(".bats"):
-            fail("srcs should have `.bats` extensions")
-
         # Prefixed with `name` to allow parameterization with macros
         # The test name should not end with `.bats`
         test_name = name + "_" + src[:-5]

--- a/rules.bzl
+++ b/rules.bzl
@@ -1,5 +1,6 @@
 load("@rules_pkg//pkg:providers.bzl", "PackageVariablesInfo")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@bazel_bats//:rules.bzl", "bats_test")
 
 # Taken from Bazel repository
 def _basic_naming_impl(ctx):
@@ -105,4 +106,32 @@ run_make = rule(
     executable = True,
     implementation = _run_make_impl,
 )
+
 ### END RUN MAKE RULE ###
+
+### BATS TEST SUITE ###
+# TODO: Remove when https://github.com/filmil/bazel-bats/pull/18 is merged and a new `bazel-bats` release is out
+def bats_test_suite(name, srcs, **kwargs):
+    tests = []
+
+    for src in srcs:
+        if not src.endswith(".bats"):
+            fail("srcs should have `.bats` extensions")
+
+        # Prefixed with `name` to allow parameterization with macros
+        # The test name should not end with `.bats`
+        test_name = name + "_" + src[:-5]
+        bats_test(
+            name = test_name,
+            srcs = [src],
+            **kwargs
+        )
+        tests.append(test_name)
+
+    native.test_suite(
+        name = name,
+        tests = tests,
+        tags = kwargs.get("tags", None),
+    )
+
+### END BATS TEST SUITE ###

--- a/tests/resiliency/kvstore/BUILD.bazel
+++ b/tests/resiliency/kvstore/BUILD.bazel
@@ -1,13 +1,15 @@
-load("@bazel_bats//:rules.bzl", "bats_test")
+load("//:rules.bzl", "bats_test_suite")
 
-bats_test(
+# Run the entire test suite with
+#   $ bazel test //tests/resiliency/kvstore:bats-resiliency-kvstore
+# or a single test with
+#   $ bazel test //tests/resiliency/kvstore:bats-resiliency-kvstore_FILE_NAME_MINUS_EXT
+# E.g.
+#   $ bazel test //tests/resiliency/kvstore:bats-resiliency-kvstore_abci-allow-addrs
+bats_test_suite(
     name = "bats-resiliency-kvstore",
-    srcs = [
-        "abci-allow-addrs.bats",
-        "catch-up.bats",
-        "persistent_store.bats",
-        "up-down.bats",
-    ],
+    timeout = "long",
+    srcs = glob(include = ["*.bats"]),
     data = [
         "//docker:jsonnet_image.tar",
         "//docker:openssl_image.tar",
@@ -15,7 +17,10 @@ bats_test(
         "//src/many-abci:many-abci-image.tar",
         "//src/many-kvstore:many-kvstore-image.tar",
     ],
-    tags = ["manual"],
+    tags = [
+        "exclusive",
+        "manual",
+    ],
     uses_bats_assert = True,
     deps = [
         "//docker:docker-kvstore-deps",

--- a/tests/resiliency/ledger/BUILD.bazel
+++ b/tests/resiliency/ledger/BUILD.bazel
@@ -1,18 +1,15 @@
-load("@bazel_bats//:rules.bzl", "bats_test")
+load("//:rules.bzl", "bats_test_suite")
 
-bats_test(
+# Run the entire test suite with
+#   $ bazel test //tests/resiliency/ledger:bats-resiliency-ledger
+# or a single test with
+#   $ bazel test //tests/resiliency/ledger:bats-resiliency-ledger_FILE_NAME_MINUS_EXT
+# E.g.
+#   $ bazel test //tests/resiliency/ledger:bats-resiliency-ledger_abci-allow-addrs
+bats_test_suite(
     name = "bats-resiliency-ledger",
-    srcs = [
-        "abci-allow-addrs.bats",
-        "account_count_migration.bats",
-        "catch-up.bats",
-        "dummy_migration.bats",
-        "memo_migration.bats",
-        "persistent_store.bats",
-        "token_migration.bats",
-        "token_subresource.bats",
-        "up-down.bats",
-    ],
+    timeout = "long",
+    srcs = glob(include = ["*.bats"]),
     data = [
         "//docker:jsonnet_image.tar",
         "//docker:openssl_image.tar",
@@ -20,7 +17,10 @@ bats_test(
         "//src/many-abci:many-abci-image.tar",
         "//src/many-ledger:many-ledger-image.tar",
     ],
-    tags = ["manual"],
+    tags = [
+        "exclusive",
+        "manual",
+    ],
     uses_bats_assert = True,
     deps = [
         "//docker:docker-ledger-deps",


### PR DESCRIPTION
With this rule, one can write a single test suite encapsulating all tests from a source while still being able to run the individual tests.

Fixes #318 


![2023-02-24_16-11](https://user-images.githubusercontent.com/1102868/221297241-a49ade32-a0fa-4998-a231-68891027b7ee.png)
![2023-02-24_16-16](https://user-images.githubusercontent.com/1102868/221297267-1f58e5fc-648d-4616-8ccc-a7b47f48917b.png)
