### PR TITLE
ci: macOS resource class deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ executors:
     resource_class: large # 4 cores, 15Gb
   macos:
     macos:
-      xcode: 13.4.1
-    resource_class: medium # 4 cores, 8Gb
+      xcode: 14.2.0
+    resource_class: macos.x86.medium.gen2 # 4 cores, 8Gb
 
 MANY_HSM_CONFIG: &many_hsm_config
   - PKCS11_SOFTHSM2_MODULE: /usr/lib/softhsm/libsofthsm2.so

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,10 +541,10 @@ workflows:
           test_name: << pipeline.parameters.test_name >>
 
   nightly_macos:
-    when:
-      and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ "macOS nightly", << pipeline.schedule.name >> ]
+#    when:
+#      and:
+#        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+#        - equal: [ "macOS nightly", << pipeline.schedule.name >> ]
     jobs:
       - lint-test-build:
           pre-steps:


### PR DESCRIPTION
macOS `medium` resource class is being deprecated.

See https://discuss.circleci.com/t/macos-resource-deprecation-update/46891