### PR TITLE
fix: sort token metadata

### DIFF
--- a/src/many-ledger/src/storage/ledger_tokens.rs
+++ b/src/many-ledger/src/storage/ledger_tokens.rs
@@ -131,6 +131,7 @@ impl LedgerStorage {
                     Op::Put(minicbor::to_vec(info).map_err(ManyError::serialization_error)?),
                 ));
             }
+            batch.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
             self.persistent_store
                 .apply(batch.as_slice())
                 .map_err(error::storage_apply_failed)?;

--- a/tests/e2e/ledger/staging.bats
+++ b/tests/e2e/ledger/staging.bats
@@ -1,4 +1,5 @@
 GIT_ROOT="$BATS_TEST_DIRNAME/../../../"
+MIGRATION_ROOT="$GIT_ROOT/tests/ledger_migrations.json"
 MFX_ADDRESS=mqbfbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wiaaaaqnz
 
 load '../../test_helper/load'
@@ -45,5 +46,44 @@ function teardown() {
         --clean \
         --persistent "ledger.db" \
         --state "$BATS_TEST_ROOTDIR/ledger_state.json5"
+    wait_for_background_output "Running accept thread"
+}
+
+@test "$SUITE: Test symbol metadata ordering when token migration enabled" {
+    local line_num;
+    cp "$GIT_ROOT/staging/ledger_state.json5" "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Add new token symbol metadata
+    line_num=$(grep -n "symbols_meta: {" "$BATS_TEST_ROOTDIR/ledger_state.json5" | cut -f1 -d ':')
+    sed -i.bak "$(( $line_num + 1 ))"'i\
+  "mqbfbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wiaaabqv7": {\
+      name: "Musicia Network Token",\
+      decimals: 9,\
+    },' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Add new token symbol
+    line_num=$(grep -n "symbols: {" "$BATS_TEST_ROOTDIR/ledger_state.json5" | cut -f1 -d ':')
+    sed -i.bak "$(( $line_num + 1 ))"'i\
+    "mqbfbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wiaaabqv7": "MUS",' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Add new token initial balance
+    line_num=$(grep -n "initial: {" "$BATS_TEST_ROOTDIR/ledger_state.json5" | cut -f1 -d ':')
+    sed -i.bak "$(( $line_num + 1 ))"'i\
+    "maephmnv6poyxvhvqewshjy2nmoo3zalm64nghxzm452vvyiks": {\
+      "MUS": 9000000000\
+    },' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+    sed -i.bak 's/fc0041ca4f7d959fe9e5a337e175bd8a68942cad76745711a3daf820a159f7eb/7ec5dbe4b59c8abbb0180822a1c71ff452dad31b01077bccfd270bea5a6ce924/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Enable token migration
+    jq '(.migrations[] | select(.name == "Token Migration")).disabled |= empty' \
+        "$MIGRATION_ROOT" > "$BATS_TEST_ROOTDIR/migrations.json"
+
+    run_in_background many-ledger  \
+        --pem $(pem 1) \
+        -v \
+        --clean \
+        --persistent "ledger.db" \
+        --state "$BATS_TEST_ROOTDIR/ledger_state.json5" \
+        --migrations-config "$BATS_TEST_ROOTDIR/migrations.json"
     wait_for_background_output "Running accept thread"
 }


### PR DESCRIPTION
Fix an issue when more than one token is defined in the staging file and the token migration is enabled from block 0