### PR TITLE
chore: bump `cucumber` to `0.19.1`

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -665,7 +665,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -957,50 +957,25 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.13.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399fa7fc41ab7163fc49d5c2613b582b04bbf2d5342fcb1946fc1efd5b71193c"
-dependencies = [
- "async-trait",
- "atty",
- "clap 3.2.23",
- "console",
- "cucumber-codegen 0.13.0",
- "cucumber-expressions",
- "derive_more",
- "either",
- "futures",
- "gherkin 0.12.0",
- "globwalk",
- "inventory 0.2.3",
- "itertools",
- "linked-hash-map",
- "once_cell",
- "regex",
- "sealed 0.4.0",
-]
-
-[[package]]
-name = "cucumber"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f3e7fc780b1bc0dc3b60e06d0e43d0fc2ed8ba6a854cf756764bcfc33aaab8"
+checksum = "a845da7c9fb958144700201d22e3f61f55114f9e269c13f03fe179d9da500984"
 dependencies = [
  "anyhow",
  "async-trait",
  "atty",
  "clap 4.1.8",
  "console",
- "cucumber-codegen 0.17.0",
+ "cucumber-codegen",
  "cucumber-expressions",
  "derive_more",
  "drain_filter_polyfill",
  "either",
  "futures",
- "gherkin 0.13.0",
+ "gherkin",
  "globwalk",
  "humantime",
- "inventory 0.3.3",
+ "inventory",
  "itertools",
  "linked-hash-map",
  "once_cell",
@@ -1008,29 +983,14 @@ dependencies = [
  "sealed 0.4.0",
  "serde",
  "serde_json",
+ "smart-default",
 ]
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.13.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f939adacd640286fb794ec392c068367991795db4c2c9112b748fb4fbf04f"
-dependencies = [
- "cucumber-expressions",
- "inflections",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "syn",
- "synthez",
-]
-
-[[package]]
-name = "cucumber-codegen"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b71f72539be877c7a0ed7464ac94936f5369ee8b9033439a0fed2103af5508f"
+checksum = "0dfb841fe8742f57fbe94738a189022e7dc858f2560c7fba5da44dc945a139e1"
 dependencies = [
  "cucumber-expressions",
  "inflections",
@@ -1724,23 +1684,6 @@ dependencies = [
 
 [[package]]
 name = "gherkin"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ab17bb865b7c4fbca5133801229aeb127e254a47c29fd26968195fce9458ab"
-dependencies = [
- "heck 0.3.3",
- "peg 0.6.3",
- "quote",
- "serde",
- "serde_json",
- "syn",
- "textwrap 0.12.1",
- "thiserror",
- "typed-builder 0.7.1",
-]
-
-[[package]]
-name = "gherkin"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8f8f49b2b547ec22cc4d99f3bf30d4889ef0dbaa231c0736eeaf20efb5a38e"
@@ -1751,9 +1694,9 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
- "textwrap 0.16.0",
+ "textwrap",
  "thiserror",
- "typed-builder 0.10.0",
+ "typed-builder",
 ]
 
 [[package]]
@@ -2184,16 +2127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "inventory"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a"
-dependencies = [
- "ctor",
- "ghost",
 ]
 
 [[package]]
@@ -2787,7 +2720,7 @@ dependencies = [
  "clap 3.2.23",
  "const_format",
  "coset",
- "cucumber 0.17.0",
+ "cucumber",
  "fixed",
  "hex",
  "itertools",
@@ -2839,7 +2772,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "coset",
- "cucumber 0.17.0",
+ "cucumber",
  "itertools",
  "many-error",
  "many-identity",
@@ -2891,7 +2824,7 @@ dependencies = [
  "cbor-diag",
  "ciborium",
  "coset",
- "cucumber 0.13.0",
+ "cucumber",
  "futures",
  "many-client",
  "many-error",
@@ -3342,9 +3275,6 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
-dependencies = [
- "parking_lot_core",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -4440,6 +4370,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smart-default"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "smawk"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4770,15 +4711,6 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
@@ -5034,17 +4966,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "typed-builder"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85f4270f4f449a3f2c0cf2aecc8415e388a597aeacc7d55fc749c5c968c8533"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "typed-builder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -957,31 +957,6 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399fa7fc41ab7163fc49d5c2613b582b04bbf2d5342fcb1946fc1efd5b71193c"
-dependencies = [
- "async-trait",
- "atty",
- "clap 3.2.23",
- "console",
- "cucumber-codegen 0.13.0",
- "cucumber-expressions",
- "derive_more",
- "either",
- "futures",
- "gherkin 0.12.0",
- "globwalk",
- "inventory 0.2.3",
- "itertools",
- "linked-hash-map",
- "once_cell",
- "regex",
- "sealed 0.4.0",
-]
-
-[[package]]
-name = "cucumber"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f3e7fc780b1bc0dc3b60e06d0e43d0fc2ed8ba6a854cf756764bcfc33aaab8"
@@ -991,16 +966,16 @@ dependencies = [
  "atty",
  "clap 4.1.8",
  "console",
- "cucumber-codegen 0.17.0",
+ "cucumber-codegen",
  "cucumber-expressions",
  "derive_more",
  "drain_filter_polyfill",
  "either",
  "futures",
- "gherkin 0.13.0",
+ "gherkin",
  "globwalk",
  "humantime",
- "inventory 0.3.3",
+ "inventory",
  "itertools",
  "linked-hash-map",
  "once_cell",
@@ -1008,22 +983,6 @@ dependencies = [
  "sealed 0.4.0",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "cucumber-codegen"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f939adacd640286fb794ec392c068367991795db4c2c9112b748fb4fbf04f"
-dependencies = [
- "cucumber-expressions",
- "inflections",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "syn",
- "synthez",
 ]
 
 [[package]]
@@ -1724,23 +1683,6 @@ dependencies = [
 
 [[package]]
 name = "gherkin"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ab17bb865b7c4fbca5133801229aeb127e254a47c29fd26968195fce9458ab"
-dependencies = [
- "heck 0.3.3",
- "peg 0.6.3",
- "quote",
- "serde",
- "serde_json",
- "syn",
- "textwrap 0.12.1",
- "thiserror",
- "typed-builder 0.7.1",
-]
-
-[[package]]
-name = "gherkin"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8f8f49b2b547ec22cc4d99f3bf30d4889ef0dbaa231c0736eeaf20efb5a38e"
@@ -1751,9 +1693,9 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
- "textwrap 0.16.0",
+ "textwrap",
  "thiserror",
- "typed-builder 0.10.0",
+ "typed-builder",
 ]
 
 [[package]]
@@ -2184,16 +2126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "inventory"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a"
-dependencies = [
- "ctor",
- "ghost",
 ]
 
 [[package]]
@@ -2787,7 +2719,7 @@ dependencies = [
  "clap 3.2.23",
  "const_format",
  "coset",
- "cucumber 0.17.0",
+ "cucumber",
  "fixed",
  "hex",
  "itertools",
@@ -2839,7 +2771,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "coset",
- "cucumber 0.17.0",
+ "cucumber",
  "itertools",
  "many-error",
  "many-identity",
@@ -2891,7 +2823,7 @@ dependencies = [
  "cbor-diag",
  "ciborium",
  "coset",
- "cucumber 0.13.0",
+ "cucumber",
  "futures",
  "many-client",
  "many-error",
@@ -3342,9 +3274,6 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
-dependencies = [
- "parking_lot_core",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -4770,15 +4699,6 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
@@ -5034,17 +4954,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "typed-builder"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85f4270f4f449a3f2c0cf2aecc8415e388a597aeacc7d55fc749c5c968c8533"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "typed-builder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f3e7fc780b1bc0dc3b60e06d0e43d0fc2ed8ba6a854cf756764bcfc33aaab8"
+checksum = "a845da7c9fb958144700201d22e3f61f55114f9e269c13f03fe179d9da500984"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -983,13 +983,14 @@ dependencies = [
  "sealed 0.4.0",
  "serde",
  "serde_json",
+ "smart-default",
 ]
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b71f72539be877c7a0ed7464ac94936f5369ee8b9033439a0fed2103af5508f"
+checksum = "0dfb841fe8742f57fbe94738a189022e7dc858f2560c7fba5da44dc945a139e1"
 dependencies = [
  "cucumber-expressions",
  "inflections",
@@ -2819,7 +2820,6 @@ dependencies = [
 name = "many-mock"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "cbor-diag",
  "ciborium",
  "coset",
@@ -4367,6 +4367,17 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smart-default"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "smawk"

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "023636a4f390e5cba66bda9b52155bcfdffdea232f53610d972b18c66e75ec55",
+  "checksum": "300d8713781a8a7ca4e3034f13ca57c9a65b41cd4d2bce8c60bbb0228444b148",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -4950,128 +4950,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "cucumber 0.13.0": {
+    "cucumber 0.19.1": {
       "name": "cucumber",
-      "version": "0.13.0",
+      "version": "0.19.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cucumber/0.13.0/download",
-          "sha256": "399fa7fc41ab7163fc49d5c2613b582b04bbf2d5342fcb1946fc1efd5b71193c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "cucumber",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "cucumber",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "cucumber-codegen",
-          "cucumber-expressions",
-          "default",
-          "inventory",
-          "macros"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "atty 0.2.14",
-              "target": "atty"
-            },
-            {
-              "id": "clap 3.2.23",
-              "target": "clap"
-            },
-            {
-              "id": "console 0.15.5",
-              "target": "console"
-            },
-            {
-              "id": "cucumber-expressions 0.2.1",
-              "target": "cucumber_expressions"
-            },
-            {
-              "id": "either 1.8.1",
-              "target": "either"
-            },
-            {
-              "id": "futures 0.3.26",
-              "target": "futures"
-            },
-            {
-              "id": "gherkin 0.12.0",
-              "target": "gherkin"
-            },
-            {
-              "id": "globwalk 0.8.1",
-              "target": "globwalk"
-            },
-            {
-              "id": "inventory 0.2.3",
-              "target": "inventory"
-            },
-            {
-              "id": "itertools 0.10.5",
-              "target": "itertools"
-            },
-            {
-              "id": "linked-hash-map 0.5.6",
-              "target": "linked_hash_map"
-            },
-            {
-              "id": "once_cell 1.17.1",
-              "target": "once_cell"
-            },
-            {
-              "id": "regex 1.7.1",
-              "target": "regex"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "async-trait 0.1.64",
-              "target": "async_trait"
-            },
-            {
-              "id": "cucumber-codegen 0.13.0",
-              "target": "cucumber_codegen"
-            },
-            {
-              "id": "derive_more 0.99.17",
-              "target": "derive_more"
-            },
-            {
-              "id": "sealed 0.4.0",
-              "target": "sealed"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.13.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "cucumber 0.17.0": {
-      "name": "cucumber",
-      "version": "0.17.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/cucumber/0.17.0/download",
-          "sha256": "24f3e7fc780b1bc0dc3b60e06d0e43d0fc2ed8ba6a854cf756764bcfc33aaab8"
+          "url": "https://crates.io/api/v1/crates/cucumber/0.19.1/download",
+          "sha256": "a845da7c9fb958144700201d22e3f61f55114f9e269c13f03fe179d9da500984"
         }
       },
       "targets": [
@@ -5181,7 +5066,7 @@
               "target": "async_trait"
             },
             {
-              "id": "cucumber-codegen 0.17.0",
+              "id": "cucumber-codegen 0.19.1",
               "target": "cucumber_codegen"
             },
             {
@@ -5191,21 +5076,25 @@
             {
               "id": "sealed 0.4.0",
               "target": "sealed"
+            },
+            {
+              "id": "smart-default 0.6.0",
+              "target": "smart_default"
             }
           ],
           "selects": {}
         },
-        "version": "0.17.0"
+        "version": "0.19.1"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cucumber-codegen 0.13.0": {
+    "cucumber-codegen 0.19.1": {
       "name": "cucumber-codegen",
-      "version": "0.13.0",
+      "version": "0.19.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cucumber-codegen/0.13.0/download",
-          "sha256": "6a6f939adacd640286fb794ec392c068367991795db4c2c9112b748fb4fbf04f"
+          "url": "https://crates.io/api/v1/crates/cucumber-codegen/0.19.1/download",
+          "sha256": "0dfb841fe8742f57fbe94738a189022e7dc858f2560c7fba5da44dc945a139e1"
         }
       },
       "targets": [
@@ -5262,74 +5151,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.13.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "cucumber-codegen 0.17.0": {
-      "name": "cucumber-codegen",
-      "version": "0.17.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/cucumber-codegen/0.17.0/download",
-          "sha256": "9b71f72539be877c7a0ed7464ac94936f5369ee8b9033439a0fed2103af5508f"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "cucumber_codegen",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "cucumber_codegen",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cucumber-expressions 0.2.1",
-              "target": "cucumber_expressions"
-            },
-            {
-              "id": "inflections 1.1.1",
-              "target": "inflections"
-            },
-            {
-              "id": "itertools 0.10.5",
-              "target": "itertools"
-            },
-            {
-              "id": "proc-macro2 1.0.51",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.23",
-              "target": "quote"
-            },
-            {
-              "id": "regex 1.7.1",
-              "target": "regex"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            },
-            {
-              "id": "synthez 0.2.0",
-              "target": "synthez"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.17.0"
+        "version": "0.19.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8801,110 +8623,6 @@
       },
       "license": "MIT"
     },
-    "gherkin 0.12.0": {
-      "name": "gherkin",
-      "version": "0.12.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/gherkin/0.12.0/download",
-          "sha256": "98ab17bb865b7c4fbca5133801229aeb127e254a47c29fd26968195fce9458ab"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "gherkin",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "gherkin",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "parser",
-          "typed-builder"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "gherkin 0.12.0",
-              "target": "build_script_build"
-            },
-            {
-              "id": "peg 0.6.3",
-              "target": "peg"
-            },
-            {
-              "id": "textwrap 0.12.1",
-              "target": "textwrap"
-            },
-            {
-              "id": "thiserror 1.0.38",
-              "target": "thiserror"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "typed-builder 0.7.1",
-              "target": "typed_builder"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.12.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "heck 0.3.3",
-              "target": "heck"
-            },
-            {
-              "id": "quote 1.0.23",
-              "target": "quote"
-            },
-            {
-              "id": "serde 1.0.152",
-              "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.93",
-              "target": "serde_json"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "gherkin 0.13.0": {
       "name": "gherkin",
       "version": "0.13.0",
@@ -11016,49 +10734,6 @@
         "version": "0.1.12"
       },
       "license": "BSD-3-Clause"
-    },
-    "inventory 0.2.3": {
-      "name": "inventory",
-      "version": "0.2.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/inventory/0.2.3/download",
-          "sha256": "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "inventory",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "inventory",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "ctor 0.1.26",
-              "target": "ctor"
-            },
-            {
-              "id": "ghost 0.1.7",
-              "target": "ghost"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.2.3"
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "inventory 0.3.3": {
       "name": "inventory",
@@ -13785,7 +13460,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "cucumber 0.17.0",
+              "id": "cucumber 0.19.1",
               "target": "cucumber"
             },
             {
@@ -13900,7 +13575,7 @@
               "target": "coset"
             },
             {
-              "id": "cucumber 0.17.0",
+              "id": "cucumber 0.19.1",
               "target": "cucumber"
             },
             {
@@ -14108,7 +13783,7 @@
               "target": "ciborium"
             },
             {
-              "id": "cucumber 0.13.0",
+              "id": "cucumber 0.19.1",
               "target": "cucumber"
             },
             {
@@ -16426,20 +16101,9 @@
         "crate_features": [
           "alloc",
           "default",
-          "parking_lot",
-          "parking_lot_core",
           "race",
           "std"
         ],
-        "deps": {
-          "common": [
-            {
-              "id": "parking_lot_core 0.9.7",
-              "target": "parking_lot_core"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "version": "1.17.1"
       },
@@ -22005,6 +21669,53 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "smart-default 0.6.0": {
+      "name": "smart-default",
+      "version": "0.6.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/smart-default/0.6.0/download",
+          "sha256": "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "smart_default",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "smart_default",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.51",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.23",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.109",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.6.0"
+      },
+      "license": "MIT"
+    },
     "smawk 0.3.1": {
       "name": "smawk",
       "version": "0.3.1",
@@ -23587,45 +23298,6 @@
       },
       "license": "MIT"
     },
-    "textwrap 0.12.1": {
-      "name": "textwrap",
-      "version": "0.12.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/textwrap/0.12.1/download",
-          "sha256": "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "textwrap",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "textwrap",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "unicode-width 0.1.10",
-              "target": "unicode_width"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.12.1"
-      },
-      "license": "MIT"
-    },
     "textwrap 0.16.0": {
       "name": "textwrap",
       "version": "0.16.0",
@@ -24960,53 +24632,6 @@
         },
         "edition": "2018",
         "version": "0.10.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "typed-builder 0.7.1": {
-      "name": "typed-builder",
-      "version": "0.7.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/typed-builder/0.7.1/download",
-          "sha256": "f85f4270f4f449a3f2c0cf2aecc8415e388a597aeacc7d55fc749c5c968c8533"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "typed_builder",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "typed_builder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.51",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.23",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.7.1"
       },
       "license": "MIT/Apache-2.0"
     },

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -54,7 +54,7 @@ tracing = "0.1.28"
 typenum = "1.15.0"
 
 [dev-dependencies]
-cucumber = { version = "0.17.0", features = ["libtest"] }
+cucumber = { version = "0.19.1", features = ["libtest"] }
 once_cell = "1.12"
 many-identity = { path = "../many-identity", features = ["default", "serde", "testing"], version = "0.1.0" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = [ "ed25519", "testing" ], version = "0.1.0" } # managed by release.sh

--- a/src/many-ledger/test-utils/Cargo.toml
+++ b/src/many-ledger/test-utils/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 async-channel = "1.8"
 coset = "0.3"
-cucumber = { version = "0.17.0", features = ["libtest"] }
+cucumber = { version = "0.19.1", features = ["libtest"] }
 itertools = "0.10.3"
 many-error = { path = "../../many-error", version = "0.1.0" } # managed by release.sh
 many-identity = { path = "../../many-identity", features = ["default", "serde", "testing"], version = "0.1.0" } # managed by release.sh

--- a/src/many-mock/Cargo.toml
+++ b/src/many-mock/Cargo.toml
@@ -21,7 +21,7 @@ many-server = { path = "../many-server", version = "0.1.0" } # managed by releas
 cbor-diag = "0.1"
 
 [dev-dependencies]
-cucumber = "0.13"
+cucumber = { version = "0.19.1", features = ["libtest"] }
 futures = "0.3"
 many-client = { path = "../many-client", version = "0.1.0" } # managed by release.sh
 serde_json = "1.0"

--- a/src/many-mock/src/server.rs
+++ b/src/many-mock/src/server.rs
@@ -44,8 +44,6 @@ impl<I: Identity + Debug + Send + Sync> LowLevelManyRequestHandler for ManyMockS
     async fn execute(&self, envelope: CoseSign1) -> Result<CoseSign1, String> {
         let request = many_protocol::decode_request_from_cose_sign1(&envelope, &self.verifier);
         let id = &self.identity;
-        let a: Vec<_> = self.mock_entries.keys().cloned().collect();
-        println!("{a:?}");
 
         let message = request.map_err(|_| "Error processing the request".to_string())?;
         let response = self

--- a/src/many-mock/src/server.rs
+++ b/src/many-mock/src/server.rs
@@ -44,6 +44,8 @@ impl<I: Identity + Debug + Send + Sync> LowLevelManyRequestHandler for ManyMockS
     async fn execute(&self, envelope: CoseSign1) -> Result<CoseSign1, String> {
         let request = many_protocol::decode_request_from_cose_sign1(&envelope, &self.verifier);
         let id = &self.identity;
+        let a: Vec<_> = self.mock_entries.keys().cloned().collect();
+        println!("{a:?}");
 
         let message = request.map_err(|_| "Error processing the request".to_string())?;
         let response = self


### PR DESCRIPTION
Build and use a single `cucumber` version across all crates.