### PR TITLE
chore: update cliff configuration

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -43,19 +43,21 @@ commit_preprocessors = [
 commit_parsers = [
     { message = "^feat", group = "Features"},
     { message = "^fix", group = "Bug Fixes"},
-    { message = "^doc", group = "Documentation"},
+    { message = "^docs?", group = "Documentation"},
     { message = "^perf", group = "Performance"},
     { message = "^refactor", group = "Refactor"},
     { message = "^style", group = "Styling"},
     { message = "^test", group = "Testing"},
     { message = "^chore\\(release\\): prepare for", skip = true},
     { message = "^chore", group = "Miscellaneous Tasks"},
+    { message = "^ci", group = "CI"},
+    { message = "^build", group = "Build"},
     { body = ".*security", group = "Security"},
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers
-filter_commits = false
+filter_commits = true
 # glob pattern for matching git tags
 tag_pattern = "v[0-9]*"
 # regex for skipping tags


### PR DESCRIPTION
Add new commit parsers and filter out commits that are not matched by commit parsers.