### PR TITLE
chore: bump dependencies

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -225,7 +225,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -334,12 +334,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -457,7 +451,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -469,12 +462,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
@@ -705,7 +692,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -1029,36 +1016,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core 0.12.4",
- "darling_macro 0.12.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1077,22 +1040,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core 0.12.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.4",
+ "darling_core",
  "quote",
  "syn 1.0.109",
 ]
@@ -1147,41 +1099,20 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
- "derive_builder_macro 0.10.2",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
-dependencies = [
- "derive_builder_macro 0.11.2",
+ "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling 0.12.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
-dependencies = [
- "darling 0.14.4",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1189,21 +1120,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
- "derive_builder_core 0.10.2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
-dependencies = [
- "derive_builder_core 0.11.2",
+ "derive_builder_core",
  "syn 1.0.109",
 ]
 
@@ -1384,26 +1305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1680,18 +1581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "gherkin"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,7 +1605,7 @@ checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2070,7 +1959,7 @@ dependencies = [
 name = "idstore-export"
 version = "0.1.1"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "clap 3.2.23",
  "merk",
  "serde",
@@ -2121,6 +2010,18 @@ dependencies = [
  "lazy_static",
  "number_prefix",
  "regex",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2236,7 +2137,7 @@ version = "0.1.1"
 dependencies = [
  "clap 3.2.23",
  "hex",
- "indicatif",
+ "indicatif 0.17.3",
  "log-panics",
  "many-client",
  "many-error",
@@ -2273,7 +2174,7 @@ dependencies = [
  "crc-any",
  "hex",
  "humantime",
- "indicatif",
+ "indicatif 0.16.2",
  "lazy_static",
  "many-cli-helpers",
  "many-client",
@@ -2287,7 +2188,7 @@ dependencies = [
  "minicbor",
  "num-bigint",
  "regex",
- "rpassword 6.0.1",
+ "rpassword 7.2.0",
  "serde_json",
  "tokio",
  "tracing",
@@ -2408,7 +2309,7 @@ checksum = "c880e0101fc5844ae1c2f3b5b50aba1fb1939e308149dc2dde33b80a0816df18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2459,7 +2360,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "atty",
- "base64 0.13.1",
+ "base64 0.21.0",
  "cbor-diag",
  "clap 3.2.23",
  "coset",
@@ -2478,7 +2379,7 @@ dependencies = [
  "many-types",
  "minicbor",
  "rand 0.8.5",
- "rpassword 6.0.1",
+ "rpassword 7.2.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2546,12 +2447,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base32",
- "base64 0.13.1",
+ "base64 0.21.0",
  "coset",
  "crc-any",
- "derive_builder 0.10.2",
+ "derive_builder",
  "ecdsa",
- "ed25519 1.5.3",
+ "ed25519 2.2.0",
  "ed25519-dalek",
  "fixed",
  "hex",
@@ -2572,7 +2473,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
- "sha3 0.9.1",
+ "sha3",
  "static_assertions",
  "tiny_http",
  "tokio",
@@ -2585,7 +2486,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2615,7 +2516,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_test",
- "sha3 0.10.6",
+ "sha3",
  "static_assertions",
  "tracing",
 ]
@@ -2642,7 +2543,7 @@ dependencies = [
  "serde",
  "serde_test",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
  "tracing",
 ]
 
@@ -2668,7 +2569,7 @@ name = "many-identity-webauthn"
 version = "0.1.1"
 dependencies = [
  "authenticator-ctap2-2021",
- "base64 0.13.1",
+ "base64 0.21.0",
  "base64urlsafedata",
  "coset",
  "hex",
@@ -2681,7 +2582,7 @@ dependencies = [
  "minicbor",
  "once_cell",
  "rand 0.8.5",
- "rpassword 5.0.1",
+ "rpassword 7.2.0",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -2716,7 +2617,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "serde",
- "sha3 0.10.6",
+ "sha3",
  "signal-hook",
  "strum",
  "tempfile",
@@ -2731,7 +2632,7 @@ version = "0.1.1"
 dependencies = [
  "async-channel",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bip39-dict",
  "clap 3.2.23",
  "const_format",
@@ -2764,7 +2665,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha3 0.9.1",
+ "sha3",
  "signal-hook",
  "strum",
  "tempfile",
@@ -2779,7 +2680,7 @@ name = "many-ledger-test-macros"
 version = "0.1.1"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2816,7 +2717,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2854,7 +2755,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 0.7.3",
 ]
 
 [[package]]
@@ -2865,7 +2766,7 @@ dependencies = [
  "async-trait",
  "cbor-diag",
  "coset",
- "derive_builder 0.11.2",
+ "derive_builder",
  "hex",
  "many-error",
  "many-identity",
@@ -2889,9 +2790,9 @@ name = "many-protocol"
 version = "0.1.1"
 dependencies = [
  "async-channel",
- "base64 0.13.1",
+ "base64 0.21.0",
  "coset",
- "derive_builder 0.10.2",
+ "derive_builder",
  "hex",
  "many-error",
  "many-identity",
@@ -2915,10 +2816,10 @@ dependencies = [
  "async-trait",
  "backtrace",
  "base32",
- "base64 0.13.1",
+ "base64 0.21.0",
  "coset",
  "crc-any",
- "derive_builder 0.10.2",
+ "derive_builder",
  "fixed",
  "hex",
  "many-error",
@@ -2939,7 +2840,7 @@ dependencies = [
  "regex",
  "semver",
  "serde",
- "sha3 0.9.1",
+ "sha3",
  "smol",
  "static_assertions",
  "strum",
@@ -2952,7 +2853,7 @@ dependencies = [
 name = "many-types"
 version = "0.1.1"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "cbor-diag",
  "coset",
  "derive_more",
@@ -3020,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a20020e8e2d1881d8736f64011bb5ff99f1db9947ce3089706945c8915695cb"
+checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
 dependencies = [
  "half 1.8.2",
  "minicbor-derive",
@@ -3030,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor-derive"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8608fb1c805b5b6b3d5ab7bd95c40c396df622b64d77b2d621a5eae1eed050ee"
+checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3157,15 +3058,6 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "ntapi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3464,11 +3356,12 @@ checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "31687a56a7298a78519d971a1dfeee8e08d8e6bf9407b9233c985538c79e1123"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
+ "serde",
 ]
 
 [[package]]
@@ -3595,6 +3488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3675,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -3946,13 +3845,22 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "6.0.1"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
 dependencies = [
  "libc",
- "serde",
- "serde_json",
+ "rtoolbox",
+ "winapi",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+dependencies = [
+ "libc",
  "winapi",
 ]
 
@@ -4222,7 +4130,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -4244,7 +4152,16 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.12",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4258,13 +4175,14 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
+checksum = "8a00ffd23fd882d096f09fcaae2a9de8329a328628e86027e049ee051dc1621f"
 dependencies = [
  "proc-macro2",
+ "quote",
  "serde",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -4312,18 +4230,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -4523,9 +4429,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4575,20 +4481,6 @@ dependencies = [
  "quote",
  "sealed 0.3.0",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.27.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
 ]
 
 [[package]]
@@ -4672,7 +4564,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint",
- "toml",
+ "toml 0.5.11",
  "url",
 ]
 
@@ -4780,7 +4672,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -4822,15 +4714,14 @@ dependencies = [
 
 [[package]]
 name = "tiny_http"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d6ef4e10d23c1efb862eecad25c5054429a71958b4eeef85eb5e7170b477ca"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
 dependencies = [
  "ascii",
  "chunked_transfer",
+ "httpdate",
  "log",
- "time",
- "url",
 ]
 
 [[package]]
@@ -4924,10 +4815,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -4936,6 +4842,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -5145,19 +5053,13 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "00f9f3c0ac17bba2cce5ba26fc17a26cb93e099626b6c3260882cecb08a1e2b4"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
- "enum-iterator",
- "getset",
  "git2",
- "rustc_version",
  "rustversion",
- "sysinfo",
- "thiserror",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]
 
@@ -107,7 +107,7 @@ checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ checksum = "bfab79c195875e5aef2bd20b4c8ed8d43ef9610bcffefbbcf66f88f555cc78af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -243,7 +243,7 @@ checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -338,12 +338,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -383,7 +377,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.109",
  "which",
 ]
 
@@ -404,7 +398,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -458,7 +452,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -470,12 +463,6 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
@@ -694,7 +681,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -707,7 +694,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -952,7 +939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -998,7 +985,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.109",
  "synthez",
 ]
 
@@ -1031,36 +1018,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core 0.12.4",
- "darling_macro 0.12.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
- "darling_core 0.14.3",
- "darling_macro 0.14.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1074,18 +1037,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core 0.12.4",
- "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1094,9 +1046,9 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
- "darling_core 0.14.3",
+ "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1144,69 +1096,38 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "derive_builder"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
- "derive_builder_macro 0.10.2",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
-dependencies = [
- "derive_builder_macro 0.11.2",
+ "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling 0.12.4",
+ "darling",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
-dependencies = [
- "darling 0.14.3",
- "proc-macro2",
- "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
- "derive_builder_core 0.10.2",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
-dependencies = [
- "derive_builder_core 0.11.2",
- "syn",
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1219,7 +1140,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1266,7 +1187,7 @@ checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1311,7 +1232,7 @@ checksum = "e9907e1f07d6b49fc8cfc92870aae890618671e932db9b7b9224d530eddde2cb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1386,26 +1307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1602,7 +1503,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1671,18 +1572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "gherkin"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1582,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.109",
  "textwrap",
  "thiserror",
  "typed-builder",
@@ -1707,7 +1596,7 @@ checksum = "41973d4c45f7a35af8753ba3457cc99d406d863941fd7f52663cff54a5ab99b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2061,7 +1950,7 @@ dependencies = [
 name = "idstore-export"
 version = "0.1.1"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "clap 3.2.23",
  "merk",
  "serde",
@@ -2112,6 +2001,18 @@ dependencies = [
  "lazy_static",
  "number_prefix",
  "regex",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2226,7 +2127,7 @@ version = "0.1.1"
 dependencies = [
  "clap 3.2.23",
  "hex",
- "indicatif",
+ "indicatif 0.17.3",
  "log-panics",
  "many-client",
  "many-error",
@@ -2263,7 +2164,7 @@ dependencies = [
  "crc-any",
  "hex",
  "humantime",
- "indicatif",
+ "indicatif 0.16.2",
  "lazy_static",
  "many-cli-helpers",
  "many-client",
@@ -2277,7 +2178,7 @@ dependencies = [
  "minicbor",
  "num-bigint",
  "regex",
- "rpassword 6.0.1",
+ "rpassword 7.2.0",
  "serde_json",
  "tokio",
  "tracing",
@@ -2398,7 +2299,7 @@ checksum = "83f2011c1121c45eb4d9639cf5dcbae9622d2978fc5e922a346bfdc6c46700b5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2443,7 +2344,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "atty",
- "base64 0.13.1",
+ "base64 0.21.0",
  "cbor-diag",
  "clap 3.2.23",
  "coset",
@@ -2462,7 +2363,7 @@ dependencies = [
  "many-types",
  "minicbor",
  "rand 0.8.5",
- "rpassword 6.0.1",
+ "rpassword 7.2.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2530,12 +2431,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base32",
- "base64 0.13.1",
+ "base64 0.21.0",
  "coset",
  "crc-any",
- "derive_builder 0.10.2",
+ "derive_builder",
  "ecdsa",
- "ed25519 1.5.3",
+ "ed25519 2.2.0",
  "ed25519-dalek",
  "fixed",
  "hex",
@@ -2556,7 +2457,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
- "sha3 0.9.1",
+ "sha3",
  "static_assertions",
  "tiny_http",
  "tokio",
@@ -2569,7 +2470,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2599,7 +2500,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_test",
- "sha3 0.10.6",
+ "sha3",
  "static_assertions",
  "tracing",
 ]
@@ -2626,7 +2527,7 @@ dependencies = [
  "serde",
  "serde_test",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
  "tracing",
 ]
 
@@ -2652,7 +2553,7 @@ name = "many-identity-webauthn"
 version = "0.1.1"
 dependencies = [
  "authenticator-ctap2-2021",
- "base64 0.13.1",
+ "base64 0.21.0",
  "base64urlsafedata",
  "coset",
  "hex",
@@ -2665,7 +2566,7 @@ dependencies = [
  "minicbor",
  "once_cell",
  "rand 0.8.5",
- "rpassword 5.0.1",
+ "rpassword 7.2.0",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -2700,7 +2601,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "serde",
- "sha3 0.10.6",
+ "sha3",
  "signal-hook",
  "strum",
  "tempfile",
@@ -2715,7 +2616,7 @@ version = "0.1.1"
 dependencies = [
  "async-channel",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bip39-dict",
  "clap 3.2.23",
  "const_format",
@@ -2748,7 +2649,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha3 0.9.1",
+ "sha3",
  "signal-hook",
  "strum",
  "tempfile",
@@ -2763,7 +2664,7 @@ name = "many-ledger-test-macros"
 version = "0.1.1"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2800,7 +2701,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream",
- "syn",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2838,7 +2739,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 0.7.3",
 ]
 
 [[package]]
@@ -2849,7 +2750,7 @@ dependencies = [
  "async-trait",
  "cbor-diag",
  "coset",
- "derive_builder 0.11.2",
+ "derive_builder",
  "hex",
  "many-error",
  "many-identity",
@@ -2873,9 +2774,9 @@ name = "many-protocol"
 version = "0.1.1"
 dependencies = [
  "async-channel",
- "base64 0.13.1",
+ "base64 0.21.0",
  "coset",
- "derive_builder 0.10.2",
+ "derive_builder",
  "hex",
  "many-error",
  "many-identity",
@@ -2899,10 +2800,10 @@ dependencies = [
  "async-trait",
  "backtrace",
  "base32",
- "base64 0.13.1",
+ "base64 0.21.0",
  "coset",
  "crc-any",
- "derive_builder 0.10.2",
+ "derive_builder",
  "fixed",
  "hex",
  "many-error",
@@ -2923,7 +2824,7 @@ dependencies = [
  "regex",
  "semver",
  "serde",
- "sha3 0.9.1",
+ "sha3",
  "smol",
  "static_assertions",
  "strum",
@@ -2936,7 +2837,7 @@ dependencies = [
 name = "many-types"
 version = "0.1.1"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "cbor-diag",
  "coset",
  "derive_more",
@@ -3004,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a20020e8e2d1881d8736f64011bb5ff99f1db9947ce3089706945c8915695cb"
+checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
 dependencies = [
  "half 1.8.2",
  "minicbor-derive",
@@ -3014,13 +2915,13 @@ dependencies = [
 
 [[package]]
 name = "minicbor-derive"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8608fb1c805b5b6b3d5ab7bd95c40c396df622b64d77b2d621a5eae1eed050ee"
+checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3074,7 +2975,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3143,15 +3044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "ntapi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,7 +3072,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3243,7 +3135,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3305,7 +3197,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3448,11 +3340,12 @@ checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "31687a56a7298a78519d971a1dfeee8e08d8e6bf9407b9233c985538c79e1123"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
+ "serde",
 ]
 
 [[package]]
@@ -3500,7 +3393,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3531,7 +3424,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3575,6 +3468,12 @@ dependencies = [
  "wepoll-ffi",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -3640,7 +3539,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -3657,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -3705,7 +3604,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3731,9 +3630,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3928,13 +3827,22 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "6.0.1"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
 dependencies = [
  "libc",
- "serde",
- "serde_json",
+ "rtoolbox",
+ "winapi",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+dependencies = [
+ "libc",
  "winapi",
 ]
 
@@ -4080,7 +3988,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4092,7 +4000,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4190,7 +4098,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4212,7 +4120,16 @@ checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4226,13 +4143,14 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274f512d6748a01e67cbcde5b4307ab2c9d52a98a2b870a980ef0793a351deff"
+checksum = "8a00ffd23fd882d096f09fcaae2a9de8329a328628e86027e049ee051dc1621f"
 dependencies = [
  "proc-macro2",
+ "quote",
  "serde",
- "syn",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -4280,18 +4198,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -4377,7 +4283,7 @@ checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4460,7 +4366,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4490,6 +4396,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,7 +4414,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -4507,7 +4424,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033178d0acccffc5490021657006e6a8dd586ee9dc6f7c24e7608b125e568cb1"
 dependencies = [
- "syn",
+ "syn 1.0.109",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -4518,7 +4435,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69263462a40e46960f070618e20094ce69e783a41f86e54bc75545136afd597a"
 dependencies = [
- "syn",
+ "syn 1.0.109",
  "synthez-core",
 ]
 
@@ -4531,21 +4448,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed 0.3.0",
- "syn",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.27.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4629,7 +4532,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint",
- "toml",
+ "toml 0.5.11",
  "url",
 ]
 
@@ -4737,7 +4640,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4779,15 +4682,14 @@ dependencies = [
 
 [[package]]
 name = "tiny_http"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d6ef4e10d23c1efb862eecad25c5054429a71958b4eeef85eb5e7170b477ca"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
 dependencies = [
  "ascii",
  "chunked_transfer",
+ "httpdate",
  "log",
- "time",
- "url",
 ]
 
 [[package]]
@@ -4833,7 +4735,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4881,18 +4783,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -4923,7 +4842,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4975,7 +4894,7 @@ checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5102,19 +5021,13 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "00f9f3c0ac17bba2cce5ba26fc17a26cb93e099626b6c3260882cecb08a1e2b4"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
- "enum-iterator",
- "getset",
  "git2",
- "rustc_version",
  "rustversion",
- "sysinfo",
- "thiserror",
  "time",
 ]
 
@@ -5193,7 +5106,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -5227,7 +5140,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5472,9 +5385,9 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winnow"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]
@@ -5523,6 +5436,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6adfed5a5610b6d79dcbd513a219cb1cd6570c00ac6efac4b717b68e3e629457",
+  "checksum": "a75baa99e4ee1cb0780d2dd324e11929600b213b6044bd56d29899bb4d4f6d28",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -502,7 +502,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -553,7 +553,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -600,7 +600,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -1149,7 +1149,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -1157,7 +1157,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.8",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -1243,7 +1243,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -1251,7 +1251,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.8",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -1767,40 +1767,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "base64 0.20.0": {
-      "name": "base64",
-      "version": "0.20.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/base64/0.20.0/download",
-          "sha256": "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "base64",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "base64",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "std"
-        ],
-        "edition": "2021",
-        "version": "0.20.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "base64 0.21.0": {
       "name": "base64",
       "version": "0.21.0",
@@ -1992,7 +1958,7 @@
               "target": "peeking_take_while"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -2100,7 +2066,7 @@
               "target": "peeking_take_while"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -2442,15 +2408,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": [
-          "block-padding"
-        ],
         "deps": {
           "common": [
-            {
-              "id": "block-padding 0.2.1",
-              "target": "block_padding"
-            },
             {
               "id": "generic-array 0.14.6",
               "target": "generic_array"
@@ -2460,36 +2419,6 @@
         },
         "edition": "2018",
         "version": "0.9.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "block-padding 0.2.1": {
-      "name": "block-padding",
-      "version": "0.2.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/block-padding/0.2.1/download",
-          "sha256": "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "block_padding",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "block_padding",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.2.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3609,7 +3538,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -3663,7 +3592,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -3671,7 +3600,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.8",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -4094,7 +4023,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -5115,7 +5044,7 @@
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -5272,58 +5201,6 @@
       },
       "license": "BSD-3-Clause"
     },
-    "darling 0.12.4": {
-      "name": "darling",
-      "version": "0.12.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/darling/0.12.4/download",
-          "sha256": "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "darling",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "darling",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "suggestions"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "darling_core 0.12.4",
-              "target": "darling_core"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "darling_macro 0.12.4",
-              "target": "darling_macro"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.12.4"
-      },
-      "license": "MIT"
-    },
     "darling 0.14.4": {
       "name": "darling",
       "version": "0.14.4",
@@ -5376,69 +5253,6 @@
       },
       "license": "MIT"
     },
-    "darling_core 0.12.4": {
-      "name": "darling_core",
-      "version": "0.12.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/darling_core/0.12.4/download",
-          "sha256": "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "darling_core",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "darling_core",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "strsim",
-          "suggestions"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "fnv 1.0.7",
-              "target": "fnv"
-            },
-            {
-              "id": "ident_case 1.0.1",
-              "target": "ident_case"
-            },
-            {
-              "id": "proc-macro2 1.0.53",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.26",
-              "target": "quote"
-            },
-            {
-              "id": "strsim 0.10.0",
-              "target": "strsim"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.12.4"
-      },
-      "license": "MIT"
-    },
     "darling_core 0.14.4": {
       "name": "darling_core",
       "version": "0.14.4",
@@ -5479,7 +5293,7 @@
               "target": "ident_case"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -5499,53 +5313,6 @@
         },
         "edition": "2018",
         "version": "0.14.4"
-      },
-      "license": "MIT"
-    },
-    "darling_macro 0.12.4": {
-      "name": "darling_macro",
-      "version": "0.12.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/darling_macro/0.12.4/download",
-          "sha256": "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "darling_macro",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "darling_macro",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "darling_core 0.12.4",
-              "target": "darling_core"
-            },
-            {
-              "id": "quote 1.0.26",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.12.4"
       },
       "license": "MIT"
     },
@@ -5813,7 +5580,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -5832,13 +5599,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "derive_builder 0.10.2": {
+    "derive_builder 0.12.0": {
       "name": "derive_builder",
-      "version": "0.10.2",
+      "version": "0.12.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/derive_builder/0.10.2/download",
-          "sha256": "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+          "url": "https://crates.io/api/v1/crates/derive_builder/0.12.0/download",
+          "sha256": "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
         }
       },
       "targets": [
@@ -5865,117 +5632,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "derive_builder_macro 0.10.2",
+              "id": "derive_builder_macro 0.12.0",
               "target": "derive_builder_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.10.2"
+        "version": "0.12.0"
       },
       "license": "MIT/Apache-2.0"
     },
-    "derive_builder 0.11.2": {
-      "name": "derive_builder",
-      "version": "0.11.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/derive_builder/0.11.2/download",
-          "sha256": "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "derive_builder",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "derive_builder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "std"
-        ],
-        "edition": "2015",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "derive_builder_macro 0.11.2",
-              "target": "derive_builder_macro"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.11.2"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "derive_builder_core 0.10.2": {
+    "derive_builder_core 0.12.0": {
       "name": "derive_builder_core",
-      "version": "0.10.2",
+      "version": "0.12.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/derive_builder_core/0.10.2/download",
-          "sha256": "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "derive_builder_core",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "derive_builder_core",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "darling 0.12.4",
-              "target": "darling"
-            },
-            {
-              "id": "proc-macro2 1.0.53",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.26",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.10.2"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "derive_builder_core 0.11.2": {
-      "name": "derive_builder_core",
-      "version": "0.11.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/derive_builder_core/0.11.2/download",
-          "sha256": "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
+          "url": "https://crates.io/api/v1/crates/derive_builder_core/0.12.0/download",
+          "sha256": "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
         }
       },
       "targets": [
@@ -6001,7 +5674,7 @@
               "target": "darling"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -6016,17 +5689,17 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.11.2"
+        "version": "0.12.0"
       },
       "license": "MIT/Apache-2.0"
     },
-    "derive_builder_macro 0.10.2": {
+    "derive_builder_macro 0.12.0": {
       "name": "derive_builder_macro",
-      "version": "0.10.2",
+      "version": "0.12.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/derive_builder_macro/0.10.2/download",
-          "sha256": "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+          "url": "https://crates.io/api/v1/crates/derive_builder_macro/0.12.0/download",
+          "sha256": "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
         }
       },
       "targets": [
@@ -6048,7 +5721,7 @@
         "deps": {
           "common": [
             {
-              "id": "derive_builder_core 0.10.2",
+              "id": "derive_builder_core 0.12.0",
               "target": "derive_builder_core"
             },
             {
@@ -6059,50 +5732,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.10.2"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "derive_builder_macro 0.11.2": {
-      "name": "derive_builder_macro",
-      "version": "0.11.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/derive_builder_macro/0.11.2/download",
-          "sha256": "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "derive_builder_macro",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "derive_builder_macro",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "derive_builder_core 0.11.2",
-              "target": "derive_builder_core"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.11.2"
+        "version": "0.12.0"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -6166,7 +5796,7 @@
               "target": "convert_case"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -6389,7 +6019,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -6613,7 +6243,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -6658,7 +6288,6 @@
           "**"
         ],
         "crate_features": [
-          "default",
           "std"
         ],
         "deps": {
@@ -6997,92 +6626,6 @@
         "version": "0.8.32"
       },
       "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
-    },
-    "enum-iterator 1.4.0": {
-      "name": "enum-iterator",
-      "version": "1.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/enum-iterator/1.4.0/download",
-          "sha256": "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "enum_iterator",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "enum_iterator",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "enum-iterator-derive 1.2.0",
-              "target": "enum_iterator_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "1.4.0"
-      },
-      "license": "0BSD"
-    },
-    "enum-iterator-derive 1.2.0": {
-      "name": "enum-iterator-derive",
-      "version": "1.2.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/enum-iterator-derive/1.2.0/download",
-          "sha256": "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "enum_iterator_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "enum_iterator_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.53",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.26",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.2.0"
-      },
-      "license": "0BSD"
     },
     "errno 0.2.8": {
       "name": "errno",
@@ -8184,7 +7727,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -8624,57 +8167,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "getset 0.1.2": {
-      "name": "getset",
-      "version": "0.1.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/getset/0.1.2/download",
-          "sha256": "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "getset",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "getset",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro-error 1.0.4",
-              "target": "proc_macro_error"
-            },
-            {
-              "id": "proc-macro2 1.0.53",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.26",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.2"
-      },
-      "license": "MIT"
-    },
     "gherkin 0.13.0": {
       "name": "gherkin",
       "version": "0.13.0",
@@ -8807,7 +8299,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -8815,7 +8307,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.8",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -9880,7 +9372,7 @@
               "target": "log_panics"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -9892,7 +9384,7 @@
               "target": "syslog_tracing"
             },
             {
-              "id": "tiny_http 0.11.0",
+              "id": "tiny_http 0.12.0",
               "target": "tiny_http"
             },
             {
@@ -10452,7 +9944,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.20.0",
+              "id": "base64 0.21.0",
               "target": "base64"
             },
             {
@@ -10715,6 +10207,61 @@
         },
         "edition": "2018",
         "version": "0.16.2"
+      },
+      "license": "MIT"
+    },
+    "indicatif 0.17.3": {
+      "name": "indicatif",
+      "version": "0.17.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/indicatif/0.17.3/download",
+          "sha256": "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "indicatif",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "indicatif",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "unicode-width"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "console 0.15.5",
+              "target": "console"
+            },
+            {
+              "id": "number_prefix 0.4.0",
+              "target": "number_prefix"
+            },
+            {
+              "id": "portable-atomic 0.3.19",
+              "target": "portable_atomic"
+            },
+            {
+              "id": "unicode-width 0.1.10",
+              "target": "unicode_width"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.17.3"
       },
       "license": "MIT"
     },
@@ -11268,7 +10815,7 @@
               "target": "hex"
             },
             {
-              "id": "indicatif 0.16.2",
+              "id": "indicatif 0.17.3",
               "target": "indicatif"
             },
             {
@@ -11276,7 +10823,7 @@
               "target": "log_panics"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -11408,7 +10955,7 @@
               "target": "mime_guess"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -11420,7 +10967,7 @@
               "target": "regex"
             },
             {
-              "id": "rpassword 6.0.1",
+              "id": "rpassword 7.2.0",
               "target": "rpassword"
             },
             {
@@ -11468,7 +11015,7 @@
               "target": "merk"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             }
           ],
@@ -12109,7 +11656,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -12117,7 +11664,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.8",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -12394,7 +11941,7 @@
               "target": "atty"
             },
             {
-              "id": "base64 0.13.1",
+              "id": "base64 0.21.0",
               "target": "base64"
             },
             {
@@ -12414,7 +11961,7 @@
               "target": "hex"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -12422,7 +11969,7 @@
               "target": "rand"
             },
             {
-              "id": "rpassword 6.0.1",
+              "id": "rpassword 7.2.0",
               "target": "rpassword"
             },
             {
@@ -12530,7 +12077,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -12599,7 +12146,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.5.1",
+              "id": "vergen 8.1.0",
               "target": "vergen"
             }
           ],
@@ -12643,7 +12190,7 @@
               "target": "log_panics"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -12700,7 +12247,7 @@
               "target": "base32"
             },
             {
-              "id": "base64 0.13.1",
+              "id": "base64 0.21.0",
               "target": "base64"
             },
             {
@@ -12712,7 +12259,7 @@
               "target": "crc_any"
             },
             {
-              "id": "derive_builder 0.10.2",
+              "id": "derive_builder 0.12.0",
               "target": "derive_builder"
             },
             {
@@ -12720,7 +12267,7 @@
               "target": "ecdsa"
             },
             {
-              "id": "ed25519 1.5.3",
+              "id": "ed25519 2.2.0",
               "target": "ed25519"
             },
             {
@@ -12736,7 +12283,7 @@
               "target": "hex"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -12768,7 +12315,7 @@
               "target": "serde"
             },
             {
-              "id": "sha3 0.9.1",
+              "id": "sha3 0.10.6",
               "target": "sha3"
             },
             {
@@ -12776,7 +12323,7 @@
               "target": "static_assertions"
             },
             {
-              "id": "tiny_http 0.11.0",
+              "id": "tiny_http 0.12.0",
               "target": "tiny_http"
             },
             {
@@ -12831,7 +12378,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -12839,7 +12386,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -12877,7 +12424,7 @@
         "deps": {
           "common": [
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -12952,7 +12499,7 @@
               "target": "hex"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -13048,7 +12595,7 @@
               "target": "ed25519_dalek"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -13198,7 +12745,7 @@
               "target": "authenticator_ctap2_2021"
             },
             {
-              "id": "base64 0.13.1",
+              "id": "base64 0.21.0",
               "target": "base64"
             },
             {
@@ -13210,7 +12757,7 @@
               "target": "coset"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -13222,7 +12769,7 @@
               "target": "rand"
             },
             {
-              "id": "rpassword 5.0.1",
+              "id": "rpassword 7.2.0",
               "target": "rpassword"
             },
             {
@@ -13334,7 +12881,7 @@
               "target": "merk"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -13404,7 +12951,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.5.1",
+              "id": "vergen 8.1.0",
               "target": "vergen"
             }
           ],
@@ -13454,7 +13001,7 @@
               "target": "async_channel"
             },
             {
-              "id": "base64 0.20.0",
+              "id": "base64 0.21.0",
               "target": "base64"
             },
             {
@@ -13502,7 +13049,7 @@
               "target": "merk"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -13526,7 +13073,7 @@
               "target": "serde_json"
             },
             {
-              "id": "sha3 0.9.1",
+              "id": "sha3 0.10.6",
               "target": "sha3"
             },
             {
@@ -13592,7 +13139,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.5.1",
+              "id": "vergen 8.1.0",
               "target": "vergen"
             }
           ],
@@ -13628,7 +13175,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -13682,7 +13229,7 @@
               "target": "merk"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -13740,7 +13287,7 @@
               "target": "inflections"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -13752,11 +13299,11 @@
               "target": "serde"
             },
             {
-              "id": "serde_tokenstream 0.1.7",
+              "id": "serde_tokenstream 0.2.0",
               "target": "serde_tokenstream"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -13790,7 +13337,7 @@
         "deps": {
           "common": [
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -13865,7 +13412,7 @@
               "target": "serde"
             },
             {
-              "id": "toml 0.5.11",
+              "id": "toml 0.7.3",
               "target": "toml"
             }
           ],
@@ -13944,7 +13491,7 @@
               "target": "coset"
             },
             {
-              "id": "derive_builder 0.11.2",
+              "id": "derive_builder 0.12.0",
               "target": "derive_builder"
             },
             {
@@ -13952,7 +13499,7 @@
               "target": "hex"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -14040,7 +13587,7 @@
               "target": "async_channel"
             },
             {
-              "id": "base64 0.13.1",
+              "id": "base64 0.21.0",
               "target": "base64"
             },
             {
@@ -14048,7 +13595,7 @@
               "target": "coset"
             },
             {
-              "id": "derive_builder 0.10.2",
+              "id": "derive_builder 0.12.0",
               "target": "derive_builder"
             },
             {
@@ -14056,7 +13603,7 @@
               "target": "hex"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -14144,7 +13691,7 @@
               "target": "base32"
             },
             {
-              "id": "base64 0.13.1",
+              "id": "base64 0.21.0",
               "target": "base64"
             },
             {
@@ -14156,7 +13703,7 @@
               "target": "crc_any"
             },
             {
-              "id": "derive_builder 0.10.2",
+              "id": "derive_builder 0.12.0",
               "target": "derive_builder"
             },
             {
@@ -14168,7 +13715,7 @@
               "target": "hex"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -14192,7 +13739,7 @@
               "target": "serde"
             },
             {
-              "id": "sha3 0.9.1",
+              "id": "sha3 0.10.6",
               "target": "sha3"
             },
             {
@@ -14204,7 +13751,7 @@
               "target": "strum"
             },
             {
-              "id": "tiny_http 0.11.0",
+              "id": "tiny_http 0.12.0",
               "target": "tiny_http"
             },
             {
@@ -14280,7 +13827,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.20.0",
+              "id": "base64 0.21.0",
               "target": "base64"
             },
             {
@@ -14296,7 +13843,7 @@
               "target": "hex"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "minicbor"
             },
             {
@@ -14666,13 +14213,13 @@
       },
       "license": "MIT"
     },
-    "minicbor 0.18.0": {
+    "minicbor 0.19.1": {
       "name": "minicbor",
-      "version": "0.18.0",
+      "version": "0.19.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/minicbor/0.18.0/download",
-          "sha256": "2a20020e8e2d1881d8736f64011bb5ff99f1db9947ce3089706945c8915695cb"
+          "url": "https://crates.io/api/v1/crates/minicbor/0.19.1/download",
+          "sha256": "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
         }
       },
       "targets": [
@@ -14714,7 +14261,7 @@
               "target": "half"
             },
             {
-              "id": "minicbor 0.18.0",
+              "id": "minicbor 0.19.1",
               "target": "build_script_build"
             }
           ],
@@ -14724,13 +14271,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "minicbor-derive 0.12.0",
+              "id": "minicbor-derive 0.13.0",
               "target": "minicbor_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.18.0"
+        "version": "0.19.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -14739,13 +14286,13 @@
       },
       "license": "BlueOak-1.0.0"
     },
-    "minicbor-derive 0.12.0": {
+    "minicbor-derive 0.13.0": {
       "name": "minicbor-derive",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/minicbor-derive/0.12.0/download",
-          "sha256": "8608fb1c805b5b6b3d5ab7bd95c40c396df622b64d77b2d621a5eae1eed050ee"
+          "url": "https://crates.io/api/v1/crates/minicbor-derive/0.13.0/download",
+          "sha256": "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
         }
       },
       "targets": [
@@ -14771,7 +14318,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -14786,7 +14333,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.12.0"
+        "version": "0.13.0"
       },
       "license": "BlueOak-1.0.0"
     },
@@ -15030,7 +14577,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -15423,67 +14970,6 @@
       },
       "license": "Apache-2.0"
     },
-    "ntapi 0.4.0": {
-      "name": "ntapi",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ntapi/0.4.0/download",
-          "sha256": "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ntapi",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ntapi",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "user"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "ntapi 0.4.0",
-              "target": "build_script_build"
-            },
-            {
-              "id": "winapi 0.3.9",
-              "target": "winapi"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.4.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0 OR MIT"
-    },
     "nu-ansi-term 0.46.0": {
       "name": "nu-ansi-term",
       "version": "0.46.0",
@@ -15632,7 +15118,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -15997,7 +15483,7 @@
               "target": "proc_macro_crate"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -16362,7 +15848,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -16988,7 +16474,7 @@
               "target": "peg_runtime"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -17035,7 +16521,7 @@
               "target": "peg_runtime"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -17320,7 +16806,7 @@
               "target": "pest_meta"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -17449,7 +16935,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -17702,6 +17188,63 @@
           ],
           "selects": {}
         }
+      },
+      "license": "Apache-2.0 OR MIT"
+    },
+    "portable-atomic 0.3.19": {
+      "name": "portable-atomic",
+      "version": "0.3.19",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/portable-atomic/0.3.19/download",
+          "sha256": "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "portable_atomic",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "portable_atomic",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "fallback"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "portable-atomic 0.3.19",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.19"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -18006,7 +17549,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -18089,7 +17632,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -18118,13 +17661,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.53": {
+    "proc-macro2 1.0.54": {
       "name": "proc-macro2",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.53/download",
-          "sha256": "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.54/download",
+          "sha256": "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
         }
       },
       "targets": [
@@ -18159,7 +17702,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "build_script_build"
             },
             {
@@ -18170,7 +17713,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.53"
+        "version": "1.0.54"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -18366,7 +17909,7 @@
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -18525,7 +18068,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -19489,13 +19032,13 @@
       },
       "license": "Apache-2.0"
     },
-    "rpassword 6.0.1": {
+    "rpassword 7.2.0": {
       "name": "rpassword",
-      "version": "6.0.1",
+      "version": "7.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rpassword/6.0.1/download",
-          "sha256": "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+          "url": "https://crates.io/api/v1/crates/rpassword/7.2.0/download",
+          "sha256": "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
         }
       },
       "targets": [
@@ -19517,12 +19060,8 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.158",
-              "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.94",
-              "target": "serde_json"
+              "id": "rtoolbox 0.0.1",
+              "target": "rtoolbox"
             }
           ],
           "selects": {
@@ -19541,7 +19080,54 @@
           }
         },
         "edition": "2018",
-        "version": "6.0.1"
+        "version": "7.2.0"
+      },
+      "license": "Apache-2.0"
+    },
+    "rtoolbox 0.0.1": {
+      "name": "rtoolbox",
+      "version": "0.0.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rtoolbox/0.0.1/download",
+          "sha256": "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rtoolbox",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "rtoolbox",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.140",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.0.1"
       },
       "license": "Apache-2.0"
     },
@@ -20362,7 +19948,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -20413,7 +19999,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -20942,7 +20528,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -20954,7 +20540,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "syn 2.0.8",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -21068,7 +20654,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -21076,7 +20662,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.8",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -21084,6 +20670,48 @@
         },
         "edition": "2018",
         "version": "0.1.12"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "serde_spanned 0.6.1": {
+      "name": "serde_spanned",
+      "version": "0.6.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/serde_spanned/0.6.1/download",
+          "sha256": "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "serde_spanned",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "serde_spanned",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "serde"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.158",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.6.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -21144,13 +20772,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_tokenstream 0.1.7": {
+    "serde_tokenstream 0.2.0": {
       "name": "serde_tokenstream",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_tokenstream/0.1.7/download",
-          "sha256": "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
+          "url": "https://crates.io/api/v1/crates/serde_tokenstream/0.2.0/download",
+          "sha256": "8a00ffd23fd882d096f09fcaae2a9de8329a328628e86027e049ee051dc1621f"
         }
       },
       "targets": [
@@ -21172,22 +20800,26 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.26",
+              "target": "quote"
             },
             {
               "id": "serde 1.0.158",
               "target": "serde"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.7"
+        "version": "0.2.0"
       },
       "license": "Apache-2.0"
     },
@@ -21455,61 +21087,6 @@
         },
         "edition": "2018",
         "version": "0.10.6"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "sha3 0.9.1": {
-      "name": "sha3",
-      "version": "0.9.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/sha3/0.9.1/download",
-          "sha256": "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "sha3",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "sha3",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "default",
-          "std"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "block-buffer 0.9.0",
-              "target": "block_buffer"
-            },
-            {
-              "id": "digest 0.9.0",
-              "target": "digest"
-            },
-            {
-              "id": "keccak 0.1.3",
-              "target": "keccak"
-            },
-            {
-              "id": "opaque-debug 0.3.0",
-              "target": "opaque_debug"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.9.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -21897,7 +21474,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -22282,7 +21859,7 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -22440,7 +22017,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -22468,13 +22045,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "syn 2.0.8": {
+    "syn 2.0.12": {
       "name": "syn",
-      "version": "2.0.8",
+      "version": "2.0.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/2.0.8/download",
-          "sha256": "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+          "url": "https://crates.io/api/v1/crates/syn/2.0.12/download",
+          "sha256": "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
         }
       },
       "targets": [
@@ -22497,6 +22074,7 @@
           "clone-impls",
           "default",
           "derive",
+          "extra-traits",
           "full",
           "parsing",
           "printing",
@@ -22507,7 +22085,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -22522,7 +22100,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.8"
+        "version": "2.0.12"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -22558,7 +22136,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -22704,7 +22282,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -22731,74 +22309,6 @@
         "version": "0.2.0"
       },
       "license": "BlueOak-1.0.0"
-    },
-    "sysinfo 0.27.8": {
-      "name": "sysinfo",
-      "version": "0.27.8",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/sysinfo/0.27.8/download",
-          "sha256": "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "sysinfo",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "sysinfo",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            }
-          ],
-          "selects": {
-            "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
-              {
-                "id": "core-foundation-sys 0.8.3",
-                "target": "core_foundation_sys"
-              }
-            ],
-            "cfg(any(windows, target_os = \"linux\", target_os = \"android\"))": [
-              {
-                "id": "once_cell 1.17.1",
-                "target": "once_cell"
-              }
-            ],
-            "cfg(not(any(target_os = \"unknown\", target_arch = \"wasm32\")))": [
-              {
-                "id": "libc 0.2.140",
-                "target": "libc"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "ntapi 0.4.0",
-                "target": "ntapi"
-              },
-              {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.27.8"
-      },
-      "license": "MIT"
     },
     "syslog-tracing 0.1.0": {
       "name": "syslog-tracing",
@@ -23700,7 +23210,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -23708,7 +23218,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.8",
+              "id": "syn 2.0.12",
               "target": "syn"
             }
           ],
@@ -23899,13 +23409,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "tiny_http 0.11.0": {
+    "tiny_http 0.12.0": {
       "name": "tiny_http",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tiny_http/0.11.0/download",
-          "sha256": "e0d6ef4e10d23c1efb862eecad25c5054429a71958b4eeef85eb5e7170b477ca"
+          "url": "https://crates.io/api/v1/crates/tiny_http/0.12.0/download",
+          "sha256": "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
         }
       },
       "targets": [
@@ -23938,22 +23448,18 @@
               "target": "chunked_transfer"
             },
             {
+              "id": "httpdate 1.0.2",
+              "target": "httpdate"
+            },
+            {
               "id": "log 0.4.17",
               "target": "log"
-            },
-            {
-              "id": "time 0.3.20",
-              "target": "time"
-            },
-            {
-              "id": "url 2.3.1",
-              "target": "url"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.11.0"
+        "version": "0.12.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -24208,7 +23714,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -24423,6 +23929,62 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "toml 0.7.3": {
+      "name": "toml",
+      "version": "0.7.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/toml/0.7.3/download",
+          "sha256": "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "toml",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "toml",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "display",
+          "parse"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.158",
+              "target": "serde"
+            },
+            {
+              "id": "serde_spanned 0.6.1",
+              "target": "serde_spanned"
+            },
+            {
+              "id": "toml_datetime 0.6.1",
+              "target": "toml_datetime"
+            },
+            {
+              "id": "toml_edit 0.19.8",
+              "target": "toml_edit"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.7.3"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "toml_datetime 0.6.1": {
       "name": "toml_datetime",
       "version": "0.6.1",
@@ -24448,6 +24010,18 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": [
+          "serde"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.158",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2021",
         "version": "0.6.1"
       },
@@ -24479,13 +24053,22 @@
           "**"
         ],
         "crate_features": [
-          "default"
+          "default",
+          "serde"
         ],
         "deps": {
           "common": [
             {
               "id": "indexmap 1.9.2",
               "target": "indexmap"
+            },
+            {
+              "id": "serde 1.0.158",
+              "target": "serde"
+            },
+            {
+              "id": "serde_spanned 0.6.1",
+              "target": "serde_spanned"
             },
             {
               "id": "toml_datetime 0.6.1",
@@ -24623,7 +24206,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -24875,7 +24458,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -25595,13 +25178,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "vergen 7.5.1": {
+    "vergen 8.1.0": {
       "name": "vergen",
-      "version": "7.5.1",
+      "version": "8.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/vergen/7.5.1/download",
-          "sha256": "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+          "url": "https://crates.io/api/v1/crates/vergen/8.1.0/download",
+          "sha256": "00f9f3c0ac17bba2cce5ba26fc17a26cb93e099626b6c3260882cecb08a1e2b4"
         }
       },
       "targets": [
@@ -25630,15 +25213,10 @@
           "**"
         ],
         "crate_features": [
-          "build",
-          "cargo",
           "default",
           "git",
           "git2",
-          "rustc",
-          "rustc_version",
-          "si",
-          "sysinfo",
+          "git2-rs",
           "time"
         ],
         "deps": {
@@ -25648,69 +25226,28 @@
               "target": "anyhow"
             },
             {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "enum-iterator 1.4.0",
-              "target": "enum_iterator"
-            },
-            {
               "id": "git2 0.16.1",
-              "target": "git2"
-            },
-            {
-              "id": "rustc_version 0.4.0",
-              "target": "rustc_version"
-            },
-            {
-              "id": "sysinfo 0.27.8",
-              "target": "sysinfo"
-            },
-            {
-              "id": "thiserror 1.0.40",
-              "target": "thiserror"
+              "target": "git2",
+              "alias": "git2_rs"
             },
             {
               "id": "time 0.3.20",
               "target": "time"
             },
             {
-              "id": "vergen 7.5.1",
+              "id": "vergen 8.1.0",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "getset 0.1.2",
-              "target": "getset"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "7.5.1"
+        "version": "8.1.0"
       },
       "build_script_attrs": {
         "data_glob": [
           "**"
         ],
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.70",
-              "target": "anyhow"
-            },
-            {
-              "id": "time 0.3.20",
-              "target": "time"
-            }
-          ],
-          "selects": {}
-        },
         "proc_macro_deps": {
           "common": [
             {
@@ -26095,7 +25632,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -26249,7 +25786,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -26877,58 +26414,29 @@
           "**"
         ],
         "crate_features": [
-          "cfg",
-          "combaseapi",
           "consoleapi",
           "errhandlingapi",
-          "evntrace",
           "fileapi",
           "handleapi",
-          "heapapi",
           "hidclass",
           "hidpi",
           "hidusage",
-          "ifdef",
           "impl-debug",
           "impl-default",
-          "in6addr",
-          "inaddr",
-          "ioapiset",
-          "iphlpapi",
           "libloaderapi",
-          "lmaccess",
-          "lmapibuf",
-          "lmcons",
-          "memoryapi",
           "minwinbase",
           "minwindef",
-          "netioapi",
           "ntdef",
-          "ntlsa",
           "ntsecapi",
-          "objidl",
-          "oleauto",
-          "pdh",
-          "powerbase",
           "processenv",
-          "psapi",
-          "rpcdce",
-          "securitybaseapi",
           "setupapi",
-          "shellapi",
           "std",
-          "synchapi",
-          "sysinfoapi",
           "timezoneapi",
-          "wbemcli",
           "winbase",
           "wincon",
-          "windef",
           "winerror",
-          "winioctl",
           "winnt",
           "winreg",
-          "winsock2",
           "ws2ipdef",
           "ws2tcpip",
           "wtypesbase"
@@ -28031,7 +27539,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.53",
+              "id": "proc-macro2 1.0.54",
               "target": "proc_macro2"
             },
             {
@@ -28314,22 +27822,6 @@
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
     ],
-    "cfg(any(windows, target_os = \"linux\", target_os = \"android\"))": [
-      "aarch64-linux-android",
-      "aarch64-pc-windows-msvc",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-linux-android",
-      "i686-pc-windows-msvc",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "s390x-unknown-linux-gnu",
-      "x86_64-linux-android",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu"
-    ],
     "cfg(docsrs)": [],
     "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
       "aarch64-apple-darwin",
@@ -28360,32 +27852,6 @@
       "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-linux-android",
-      "aarch64-pc-windows-msvc",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-pc-windows-msvc",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "riscv32imc-unknown-none-elf",
-      "riscv64gc-unknown-none-elf",
-      "s390x-unknown-linux-gnu",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-linux-android",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu"
-    ],
-    "cfg(not(any(target_os = \"unknown\", target_arch = \"wasm32\")))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
       "aarch64-apple-ios-sim",

--- a/src/http_proxy/Cargo.toml
+++ b/src/http_proxy/Cargo.toml
@@ -13,17 +13,17 @@ name = "http_proxy"
 doc = false
 
 [dependencies]
-clap = { version = "3.0.0", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 hex = "0.4.3"
 log-panics = { version = "2", features = ["with-backtrace"]}
-minicbor = { version = "0.18.0", features = ["derive", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-client = { path = "../many-client", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", version = "0.1.1" } # managed by release.sh
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh
 new_mime_guess = "4.0.0"
 syslog-tracing = "0.1"
-tiny_http = "0.11.0"
+tiny_http = "0.12.0"
 tracing = "0.1.29"
 tracing-subscriber = "0.3"
 tokio = { version = "1.24.1", features = [ "full" ] }

--- a/src/idstore-export/Cargo.toml
+++ b/src/idstore-export/Cargo.toml
@@ -13,8 +13,8 @@ name = "idstore-export"
 doc = false
 
 [dependencies]
-base64 = "0.20.0"
-clap = { version = "3.0.0", features = ["derive"] }
+base64 = "0.21.0"
+clap = { version = "3.2.23", features = ["derive"] }
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
 serde = "1.0.137"
 serde_derive = "1.0.137"

--- a/src/idstore-export/src/main.rs
+++ b/src/idstore-export/src/main.rs
@@ -1,5 +1,6 @@
 extern crate core;
 
+use base64::{engine::general_purpose, Engine as _};
 use clap::Parser;
 use merk::rocksdb;
 use merk::rocksdb::{IteratorMode, ReadOptions};
@@ -37,7 +38,10 @@ fn main() {
         let new_v = Tree::decode(key.to_vec(), value.as_ref());
         let value = new_v.value().to_vec();
 
-        idstore.insert(base64::encode(key.as_ref()), base64::encode(value));
+        idstore.insert(
+            general_purpose::STANDARD.encode(key.as_ref()),
+            general_purpose::STANDARD.encode(value),
+        );
     }
 
     let root = JsonRoot {

--- a/src/kvstore/Cargo.toml
+++ b/src/kvstore/Cargo.toml
@@ -13,11 +13,11 @@ name = "kvstore"
 doc = false
 
 [dependencies]
-clap = { version = "3.0.0", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 hex = "0.4.3"
-indicatif = "0.16.2"
+indicatif = "0.17.3"
 log-panics = { version = "2", features = ["with-backtrace"]}
-minicbor = { version = "0.18.0", features = ["derive", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-client = { path = "../many-client", version = "0.1.1" } # managed by release.sh
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh

--- a/src/kvstore/src/main.rs
+++ b/src/kvstore/src/main.rs
@@ -270,7 +270,7 @@ pub(crate) fn wait_response(
 
         let progress =
             indicatif::ProgressBar::new_spinner().with_message("Waiting for async response");
-        progress.enable_steady_tick(100);
+        progress.enable_steady_tick(Duration::from_millis(100));
 
         // TODO: improve on this by using duration and thread and watchdog.
         // Wait for the server for ~60 seconds by pinging it every second.

--- a/src/ledger-db/Cargo.toml
+++ b/src/ledger-db/Cargo.toml
@@ -13,9 +13,9 @@ name = "ledger-db"
 doc = false
 
 [dependencies]
-clap = { version = "3.0.0", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 hex = "0.4.3"
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-minicbor = "0.18.0"
+minicbor = "0.19.1"

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -14,14 +14,14 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.69"
-clap = { version = "3.0.0", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 crc-any = "2.4.0"
 hex = "0.4.3"
 humantime = "2.1.0"
 indicatif = "0.16.2"
 lazy_static = "1.4.0"
 mime_guess = "2.0.4"
-minicbor = { version = "0.18.0", features = ["derive", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "std"] }
 num-bigint = "0.4.3"
 many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.1" } # managed by release.sh
 many-client = { path = "../many-client", version = "0.1.1" } # managed by release.sh
@@ -32,7 +32,7 @@ many-modules = { path = "../many-modules", version = "0.1.1" } # managed by rele
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
 regex = "1.5.4"
-rpassword = "6.0"
+rpassword = "7.2.0"
 serde_json = "1.0.91"
 tracing = "0.1.29"
 tokio = { version = "1.24.1", features = [ "full" ] }

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -17,14 +17,14 @@ doc = false
 async-trait = "0.1.51"
 base64 = "0.21.0"
 ciborium = "0.2.0"
-clap = { version = "3.0.0", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 coset = "0.3"
 hex = "0.4.3"
 itertools = "0.10.5"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 linkme = { version = "0.3.5", features = ["used_linker"] }
-minicbor = { version = "0.18.0", features = ["derive", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.1" } # managed by release.sh
 many-client = { path = "../many-client", version = "0.1.1" } # managed by release.sh
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
@@ -49,4 +49,4 @@ tokio = { version = "1.24.1", features = [ "full" ] }
 tracing = "0.1.28"
 
 [build-dependencies]
-vergen = "7"
+vergen = { version = "8.1.0", features = ["git", "git2"] }

--- a/src/many-abci/build.rs
+++ b/src/many-abci/build.rs
@@ -1,7 +1,8 @@
-use vergen::{vergen, Config};
+use std::error::Error;
+use vergen::EmitBuilder;
 
-fn main() {
-    let mut config = Config::default();
-    *config.git_mut().enabled_mut() = true;
-    vergen(config).expect("Vergen could not run.")
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder().git_sha(false).emit()?;
+    Ok(())
 }

--- a/src/many-cli-helpers/Cargo.toml
+++ b/src/many-cli-helpers/Cargo.toml
@@ -12,10 +12,10 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 
 [dependencies]
 anyhow = "1.0.69"
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 log-panics = { version = "2", features = ["with-backtrace"]}
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
-minicbor = { version = "0.18.0", features = ["derive", "std", "half"] }
+minicbor = { version = "0.19.1", features = ["derive", "std", "half"] }
 syslog-tracing = "0.1.0"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/src/many-client-macros/Cargo.toml
+++ b/src/many-client-macros/Cargo.toml
@@ -14,6 +14,6 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { version = "2.0.12", features = ["full", "extra-traits"] }
+quote = "1.0.26"
+proc-macro2 = "1.0.54"

--- a/src/many-client-macros/src/lib.rs
+++ b/src/many-client-macros/src/lib.rs
@@ -8,7 +8,6 @@ use syn::parse2;
 use syn::spanned::Spanned;
 use syn::FnArg;
 use syn::ItemTrait;
-use syn::TraitItemMethod;
 use syn::Type;
 use syn::{parse_macro_input, parse_quote, LitStr};
 
@@ -40,7 +39,7 @@ pub fn many_client(attr: TokenStream, input: TokenStream) -> TokenStream {
     let methods_vec = input_trait.items.iter().map(|func| {
         let namespace = namespace.clone();
         let func = func.to_token_stream();
-        let method: TraitItemMethod =
+        let method: syn::TraitItemFn =
             parse2(func)?;
         let mut method = method.sig;
         method.asyncness = parse_quote! { async };

--- a/src/many-client/Cargo.toml
+++ b/src/many-client/Cargo.toml
@@ -12,12 +12,12 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 anyhow = "1.0.44"
 async-trait = "0.1.51"
 base32 = "0.4.0"
-base64 = "0.13.0"
+base64 = "0.21.0"
 coset = "0.3"
 crc-any = "2.4.0"
-derive_builder = "0.10.2"
+derive_builder = "0.12.0"
 ecdsa = "0.16.0"
-ed25519 = { version = "1.2.0", features = [ "std" ] }
+ed25519 = { version = "2.2.0", features = [ "std" ] }
 ed25519-dalek = { version = "1.0.1", features = [ "std" ] }
 fixed = "1.16.0"
 hex = "0.4.3"
@@ -27,22 +27,22 @@ many-identity-dsa = { path = "../many-identity-dsa", version = "0.1.1" } # manag
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-minicbor = { version = "0.18.0", features = ["derive", "half", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "half", "std"] }
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 num-bigint = "0.4.3"
 p256 = { version = "0.13.0", features = [ "pem", "ecdsa", "std" ] }
-pem = { version = "1.0.0", optional = true }
+pem = { version = "2.0.0", optional = true }
 many-server = { path = "../many-server", version = "0.1.1" } # managed by release.sh
 rand = "0.8.4"
 regex = "1.5.4"
 reqwest = { version = "0.11.5", features = ["blocking"] }
 serde = { version = "1.0.130" }
-sha3 = "0.9.1"
+sha3 = "0.10.6"
 static_assertions = "1.1.0"
 tracing = "0.1.29"
 tokio = { version = "1.24.1", features = [ "full" ] }
-tiny_http = "0.11.0"
+tiny_http = "0.12.0"
 
 [features]
 default = []

--- a/src/many-error/Cargo.toml
+++ b/src/many-error/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 
 [dependencies]
 backtrace = { version = "0.3.66", optional = true }
-minicbor = { version = "0.18.0", optional = true, features = ["alloc"] }
+minicbor = { version = "0.19.1", optional = true, features = ["alloc"] }
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 regex = "1.6.0"

--- a/src/many-identity-dsa/Cargo.toml
+++ b/src/many-identity-dsa/Cargo.toml
@@ -18,14 +18,14 @@ ed25519 = { version = "2.1.0", features = [ "alloc", "std", "pem" ], optional = 
 ed25519-dalek = { version = "1.0.1", optional = true }
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
-minicbor = { version = "0.18.0", optional = true }
+minicbor = { version = "0.19.1", optional = true }
 once_cell = "1.10"
 p256 = { version = "0.13.0", features = [ "alloc", "pem", "ecdsa", "std" ] }
 rand = { version = "0.8" }
 rand_07 = { package = "rand", version = "0.7", optional = true }  # Version compatible with ed25519-dalek
 serde = "1.0.139"
 sha2 = "0.10.2"
-sha3 = "0.10.1"
+sha3 = "0.10.6"
 tracing = "0.1.29"
 
 [dev-dependencies]

--- a/src/many-identity-webauthn/Cargo.toml
+++ b/src/many-identity-webauthn/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 
 [dependencies]
 authenticator-ctap2-2021 = { version = "0.3.2-dev.1", optional = true, default-features = false, features = ["crypto_openssl"] }
-base64 = "0.13.0"
+base64 = "0.21.0"
 base64urlsafedata = { version = "0.1.2", optional = true }
 coset = "0.3.2"
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
@@ -21,10 +21,10 @@ many-identity-dsa = { path = "../many-identity-dsa", features = ["ecdsa"], versi
 many-modules = { path = "../many-modules", optional = true, version = "0.1.1" } # managed by release.sh
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-minicbor = "0.18.0"
+minicbor = "0.19.1"
 once_cell = "1.13.0"
 rand = { version = "0.8.5", optional = true }
-rpassword = { version = "5.0", optional = true }
+rpassword = { version = "7.2.0", optional = true }
 serde = "1.0.142"
 serde_cbor = { version = "0.11.2", optional = true }
 serde_json = "1.0.83"

--- a/src/many-identity-webauthn/src/identity/u2fhid.rs
+++ b/src/many-identity-webauthn/src/identity/u2fhid.rs
@@ -13,6 +13,7 @@
 //!
 //! The changes to this file from the original are marked with `<<<<<`
 //! and `>>>>>`.
+use std::io::BufReader;
 use tracing::{error, info, trace, warn};
 
 // >>>>>>
@@ -116,8 +117,12 @@ impl U2FHid {
                 }
                 Ok(StatusUpdate::PinError(error, sender)) => match error {
                     PinError::PinRequired => {
-                        let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
-                            .expect("Failed to read PIN");
+                        let raw_pin = rpassword::prompt_password_from_bufread(
+                            &mut BufReader::new(std::io::stdin()),
+                            &mut std::io::stderr(),
+                            "Enter PIN: ",
+                        )
+                        .expect("Failed to read PIN");
                         sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
                         continue;
                     }
@@ -138,8 +143,12 @@ impl U2FHid {
                         //     ))
                         // );
                         // <<<<<<
-                        let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
-                            .expect("Failed to read PIN");
+                        let raw_pin = rpassword::prompt_password_from_bufread(
+                            &mut BufReader::new(std::io::stdin()),
+                            &mut std::io::stderr(),
+                            "Enter PIN: ",
+                        )
+                        .expect("Failed to read PIN");
                         sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
                         continue;
                     }

--- a/src/many-identity-webauthn/src/verifier.rs
+++ b/src/many-identity-webauthn/src/verifier.rs
@@ -1,4 +1,5 @@
 use crate::challenge::Challenge;
+use base64::{engine::general_purpose, Engine as _};
 use coset::cbor::value::Value;
 use coset::{CborSerializable, CoseKey, CoseKeySet, CoseSign1, Label};
 use many_error::ManyError;
@@ -115,7 +116,8 @@ impl WebAuthnVerifier {
         let payload_sha512 = sha2::Sha512::digest(payload);
 
         tracing::trace!("Decoding `challenge`");
-        let challenge = base64::decode_config(&client_data_json.challenge, base64::URL_SAFE_NO_PAD)
+        let challenge = general_purpose::URL_SAFE_NO_PAD
+            .decode(&client_data_json.challenge)
             .map_err(ManyError::unknown)?;
         let challenge: Challenge = minicbor::decode(&challenge).map_err(ManyError::unknown)?;
         tracing::trace!("Verifying `challenge` SHA against payload");

--- a/src/many-identity/Cargo.toml
+++ b/src/many-identity/Cargo.toml
@@ -16,10 +16,10 @@ base32 = "0.4.0"
 crc-any = "2.4.3"
 coset = { version = "0.3.2", optional = true }
 hex = "0.4.3"
-minicbor = { version = "0.18.0", optional = true }
+minicbor = { version = "0.19.1", optional = true }
 once_cell = "1.10"
 serde = "1.0.139"
-sha3 = "0.10.1"
+sha3 = "0.10.6"
 static_assertions = "1.1.0"
 tracing = "0.1.29"
 

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -15,14 +15,14 @@ doc = false
 
 [dependencies]
 async-trait = "0.1.51"
-clap = { version = "3.0.0", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 coset = "0.3"
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
 hex = { version = "0.4.3", features = ["serde"] }
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 num-bigint = "0.4.3"
-minicbor = { version = "0.18.0", features = ["derive", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.1" } # managed by release.sh
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", features = ["default", "serde"], version = "0.1.1" } # managed by release.sh
@@ -32,7 +32,7 @@ many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by re
 many-server = { path = "../many-server", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
 serde = "1.0.130"
-sha3 = "0.10.4"
+sha3 = "0.10.6"
 signal-hook = "0.3.13"
 strum = "0.24.1"
 tokio = { version = "1.24.1", features = [ "full" ] }
@@ -46,5 +46,4 @@ many-identity-dsa = { path = "../many-identity-dsa", features = [ "ed25519", "te
 tempfile = "3.3.0"
 
 [build-dependencies]
-vergen = "7"
-
+vergen = { version = "8.1.0", features = ["git", "git2"] }

--- a/src/many-kvstore/build.rs
+++ b/src/many-kvstore/build.rs
@@ -1,7 +1,8 @@
-use vergen::{vergen, Config};
+use std::error::Error;
+use vergen::EmitBuilder;
 
-fn main() {
-    let mut config = Config::default();
-    *config.git_mut().enabled_mut() = true;
-    vergen(config).expect("Vergen could not run.")
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder().git_sha(false).emit()?;
+    Ok(())
 }

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -16,9 +16,9 @@ doc = false
 [dependencies]
 async-channel = "1.8"
 async-trait = "0.1.51"
-base64 = "0.20.0-alpha.1"
+base64 = "0.21.0"
 bip39-dict = "0.1"
-clap = { version = "3.0.0", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 coset = "0.3"
 const_format = "0.2.30"
 fixed = "1.11.0"
@@ -29,7 +29,7 @@ json5 = "0.4.1"
 linkme = { version = "0.3.5", features = ["used_linker"] }
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
-minicbor = { version = "0.18.0", features = ["derive", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.1" } # managed by release.sh
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", features = ["default", "serde"], version = "0.1.1" } # managed by release.sh
@@ -43,7 +43,7 @@ many-types = { path = "../many-types", version = "0.1.1" } # managed by release.
 rand = "0.8"
 serde = "1.0.130"
 serde_json = "1.0.72"
-sha3 = "0.9.1"
+sha3 = "0.10.6"
 signal-hook = "0.3.13"
 strum = "0.24.1"
 tokio = { version = "1.24.1", features = [ "full" ] }
@@ -85,7 +85,7 @@ path = "tests/ledger_tokens/remove_token_ext_info.rs"
 harness = false
 
 [build-dependencies]
-vergen = "7"
+vergen = { version = "8.1.0", features = ["git", "git2"] }
 
 [features]
 balance_testing=[]                  # Enable balance initialization from the CLI

--- a/src/many-ledger/build.rs
+++ b/src/many-ledger/build.rs
@@ -1,7 +1,8 @@
-use vergen::{vergen, Config};
+use std::error::Error;
+use vergen::EmitBuilder;
 
-fn main() {
-    let mut config = Config::default();
-    *config.git_mut().enabled_mut() = true;
-    vergen(config).expect("Vergen could not run.")
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder().git_sha(false).emit()?;
+    Ok(())
 }

--- a/src/many-ledger/src/storage/idstore.rs
+++ b/src/many-ledger/src/storage/idstore.rs
@@ -1,5 +1,6 @@
 use crate::error;
 use crate::storage::LedgerStorage;
+use base64::{engine::general_purpose, Engine as _};
 use many_error::ManyError;
 use many_identity::Address;
 use many_modules::idstore;
@@ -42,8 +43,12 @@ impl LedgerStorage {
         let maybe_keys = maybe_keys.map(|keys| {
             keys.iter()
                 .map(|(k, v)| {
-                    let k = base64::decode(k).expect("Invalid base64 for key");
-                    let v = base64::decode(v).expect("Invalid base64 for value");
+                    let k = general_purpose::STANDARD
+                        .decode(k)
+                        .expect("Invalid base64 for key");
+                    let v = general_purpose::STANDARD
+                        .decode(v)
+                        .expect("Invalid base64 for value");
                     (k, v)
                 })
                 .collect::<BTreeMap<_, _>>()

--- a/src/many-ledger/test-macros/Cargo.toml
+++ b/src/many-ledger/test-macros/Cargo.toml
@@ -13,5 +13,5 @@ publish = false
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
-syn = "1.0"
+quote = "1.0.26"
+syn = "2.0.12"

--- a/src/many-ledger/test-utils/Cargo.toml
+++ b/src/many-ledger/test-utils/Cargo.toml
@@ -23,7 +23,7 @@ many-modules = { path = "../../many-modules", features = ["cucumber"], version =
 many-protocol = { path = "../../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../../many-types", features = ["cucumber"], version = "0.1.1" } # managed by release.sh
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
-minicbor = { version = "0.18.0", features = ["derive", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "std"] }
 once_cell = "1.12"
 proptest = "1"
 serde_json = "1.0.72"

--- a/src/many-macros/Cargo.toml
+++ b/src/many-macros/Cargo.toml
@@ -13,9 +13,9 @@ proc-macro = true
 
 [dependencies]
 inflections = "1.1.1"
-proc-macro2 = "1.0.36"
-quote = "1.0.14"
+proc-macro2 = "1.0.54"
+quote = "1.0.26"
 serde = "1.0.134"
-serde_tokenstream = "0.1.3"
-syn = "1.0.86"
+serde_tokenstream = "0.2.0"
+syn = "2.0.12"
 

--- a/src/many-macros/src/lib.rs
+++ b/src/many-macros/src/lib.rs
@@ -6,7 +6,7 @@ use serde_tokenstream::from_tokenstream;
 use syn::parse::ParseStream;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{FnArg, Pat, PatType, ReturnType, Token, TraitItem, TraitItemMethod, Type, TypePath};
+use syn::{FnArg, Pat, PatType, ReturnType, Token, TraitItem, TraitItemFn, Type, TypePath};
 
 #[derive(Deserialize)]
 struct ManyModuleAttributes {
@@ -88,7 +88,7 @@ struct Endpoint {
 }
 
 impl Endpoint {
-    pub fn new(item: &TraitItemMethod) -> syn::Result<Self> {
+    pub fn new(item: &TraitItemFn) -> syn::Result<Self> {
         let signature = &item.sig;
 
         let func = signature.ident.clone();
@@ -199,7 +199,7 @@ impl Endpoint {
             .attrs
             .clone()
             .into_iter()
-            .partition(|attr| attr.path.is_ident("many"));
+            .partition(|attr| attr.path().is_ident("many"));
 
         let metadata =
             meta_attrs
@@ -461,7 +461,7 @@ fn many_module_impl(attr: &TokenStream, item: TokenStream) -> Result<TokenStream
         .items
         .iter()
         .filter_map(|item| {
-            if let TraitItem::Method(m) = item {
+            if let TraitItem::Fn(m) = item {
                 Some(Endpoint::new(m))
             } else {
                 None

--- a/src/many-migration/Cargo.toml
+++ b/src/many-migration/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 
 [dependencies]
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
-minicbor = { version = "0.18.0", features = ["derive"] }
+minicbor = { version = "0.19.1", features = ["derive"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 strum = { version = "0.24", features = ["derive"] }

--- a/src/many-mock/Cargo.toml
+++ b/src/many-mock/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 async-trait = "0.1"
 coset = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.5"
+toml = "0.7.3"
 regex = "1.5.4"
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh

--- a/src/many-modules/Cargo.toml
+++ b/src/many-modules/Cargo.toml
@@ -19,9 +19,9 @@ many-types = { path = "../many-types", version = "0.1.1" } # managed by release.
 async-channel = "1.8"
 async-trait = "0.1.56"
 coset = "0.3.2"
-derive_builder = "0.11.2"
+derive_builder = "0.12.0"
 hex = "0.4.3"
-minicbor = { version = "0.18.0", features = ["derive"] }
+minicbor = { version = "0.19.1", features = ["derive"] }
 num-bigint = "0.4.3"
 num_enum = "0.5.7"
 strum = "0.24.1"

--- a/src/many-protocol/Cargo.toml
+++ b/src/many-protocol/Cargo.toml
@@ -15,11 +15,11 @@ many-error = { path = "../many-error", version = "0.1.1" } # managed by release.
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
 async-channel = "1.8"
-base64 = "0.13.0"
+base64 = "0.21.0"
 coset = "0.3.2"
-derive_builder = "0.10.2"
+derive_builder = "0.12.0"
 hex = "0.4.3"
-minicbor = { version = "0.18.0", features = ["derive", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "std"] }
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 num-bigint = "0.4.3"

--- a/src/many-server/Cargo.toml
+++ b/src/many-server/Cargo.toml
@@ -16,10 +16,10 @@ anyhow = "1.0.44"
 async-trait = "0.1.51"
 backtrace = { version = "0.3", optional = true }
 base32 = "0.4.0"
-base64 = "0.13.0"
+base64 = "0.21.0"
 coset = "0.3"
 crc-any = "2.4.0"
-derive_builder = "0.10.2"
+derive_builder = "0.12.0"
 fixed = "1.16.0"
 hex = "0.4.3"
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
@@ -27,21 +27,21 @@ many-identity = { path = "../many-identity", features = ["coset", "raw"], versio
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-minicbor = { version = "0.18.0", features = ["derive", "half", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "half", "std"] }
 num-bigint = "0.4.3"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 once_cell = "1.10"
-pem = { version = "1.0.0", optional = true }
+pem = { version = "2.0.0", optional = true }
 many-macros = { path = "../many-macros", version = "0.1.1" } # managed by release.sh
 regex = "1.5.4"
 serde = { version = "1.0.130" }
-sha3 = "0.9.1"
+sha3 = "0.10.6"
 static_assertions = "1.1.0"
 strum = "0.24.0"
 strum_macros = "0.24"
 tracing = "0.1.29"
-tiny_http = "0.11.0"
+tiny_http = "0.12.0"
 
 [dev-dependencies]
 many-server = { path = ".", features = ["testing"], version = "0.1.1" } # managed by release.sh

--- a/src/many-types/Cargo.toml
+++ b/src/many-types/Cargo.toml
@@ -13,12 +13,12 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 [dependencies]
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
-base64 = "0.20.0"
+base64 = "0.21.0"
 coset = "0.3.2"
 derive_more = "0.99"
 fixed = "1.16.0"
 hex = "0.4.3"
-minicbor = { version = "0.18.0", features = ["derive", "std", "half"] }
+minicbor = { version = "0.19.1", features = ["derive", "std", "half"] }
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 num-bigint = "0.4.3"

--- a/src/many/Cargo.toml
+++ b/src/many/Cargo.toml
@@ -28,14 +28,14 @@ many-server = { path = "../many-server", version = "0.1.1" } # managed by releas
 anyhow = "1.0.57"
 async-recursion = "1.0"
 atty = "0.2.14"
-base64 = "0.13.0"
+base64 = "0.21.0"
 cbor-diag = "0.1.9"
-clap = { version = "3.0.14", features = [ "derive" ] }
+clap = { version = "3.2.23", features = [ "derive" ] }
 coset = "0.3"
 hex = "0.4.3"
-minicbor = { version = "0.18.0", features = ["derive", "half", "std"] }
+minicbor = { version = "0.19.1", features = ["derive", "half", "std"] }
 rand = "0.8.5"
-rpassword = "6.0"
+rpassword = "7.2.0"
 tracing = "0.1.29"
 tracing-subscriber = "0.3.15"
 tokio = { version = "1.24.1", features = [ "full" ] }

--- a/src/many/src/main.rs
+++ b/src/many/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use async_recursion::async_recursion;
+use base64::{engine::general_purpose, Engine as _};
 use clap::{ArgGroup, Parser};
 use coset::{CborSerializable, CoseSign1};
 use many_cli_helpers::error::ClientServerError;
@@ -599,7 +600,7 @@ async fn main() {
                 if o.hex {
                     println!("{}", hex::encode(&bytes));
                 } else if o.base64 {
-                    println!("{}", base64::encode(&bytes));
+                    println!("{}", general_purpose::STANDARD.encode(&bytes));
                 } else {
                     panic!("Must specify one of hex, base64 or server...");
                 }


### PR DESCRIPTION
* bump `syn` to `2.0.12`
* bump `base64` to `0.21.0`
* bump `derive_builder` to `0.12.0`
* bump `indicatif` to `0.17.3`
* bump `rpassword` to `7.2.0`
* bump `ed25519` to `2.2.0`
* bump `sha3` to `0.10.6`
* bump `toml` to `0.7.3`
* bump `minicbor` to `0.19.1`
* bump `pem` to `2.0.0`
* bump `tiny_http` to `0.12.0`
* bump `vergen` to `8.1.0`
* bump `proc-macro2` to `1.0.54`
* bump `quote` to `1.0.26`

The following updates will require more work and are not part of this PR.
- clap >= 4.x
- tendermint-rs >=0.30
- cryptoki >=0.4