### PR TITLE
ci: bats test reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,14 @@ jobs:
             D=${C[@]//.bats/}
 
             bazel test --test_output=errors --config=remote-cache $D
+            
+            # Collect all test reports
+            # NOTE: The combinaison of `xargs` and `sh -c` is insecure.
+            #       The risks are acceptable on CI.
+            E=$(printf " + \"%s\"" "${D[@]}")
+            mkdir -p bats-reports
+            bazel cquery 'kind(.bats, ${E:2})' --output=files | \
+              xargs -I {} sh -c 'cp {}.runfiles/__main__/report.xml ./bats-reports/$(basename {})_report.xml'
 
   # Run a single kvstore resiliency test
   kvstore_resiliency_single_test:
@@ -254,6 +262,14 @@ jobs:
             D=${C[@]//.bats/}
             
             bazel test --test_output=errors --config=remote-cache --config=bats-resiliency-ledger $D
+            
+            # Collect all test reports
+            # NOTE: The combinaison of `xargs` and `sh -c` is insecure.
+            #       The risks are acceptable on CI.
+            E=$(printf " + \"%s\"" "${D[@]}")
+            mkdir -p bats-reports
+            bazel cquery 'kind(.bats, ${E:2})' --output=files | \
+              xargs -I {} sh -c 'cp {}.runfiles/__main__/report.xml ./bats-reports/$(basename {})_report.xml'
 
   # Run a single ledger resiliency test
   ledger_resiliency_single_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,8 @@ jobs:
             mkdir -p bats-reports
             bazel cquery 'kind(.bats, ${E:2})' --output=files | \
               xargs -I {} sh -c 'cp {}.runfiles/__main__/report.xml ./bats-reports/$(basename {})_report.xml'
+      - store_test_results:
+          path: bats-reports
 
   # Run a single kvstore resiliency test
   kvstore_resiliency_single_test:
@@ -270,6 +272,8 @@ jobs:
             mkdir -p bats-reports
             bazel cquery 'kind(.bats, ${E:2})' --output=files | \
               xargs -I {} sh -c 'cp {}.runfiles/__main__/report.xml ./bats-reports/$(basename {})_report.xml'
+      - store_test_results:
+          path: bats-reports
 
   # Run a single ledger resiliency test
   ledger_resiliency_single_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,15 @@ jobs:
               # --disable_token_sender_check needs to be disabled for the token tests
               bazel test --test_output=errors --balance_testing --migration_testing --config=remote-cache //tests/e2e/ledger:bats-e2e-ledger-tokens
 
+              # Collect all test reports
+              # NOTE: The combinaison of `xargs` and `sh -c` is insecure.
+              #       The risks are acceptable on CI.
+              mkdir -p bats-reports
+              bazel cquery 'kind(.bats, "//tests/e2e/kvstore:*" + "//tests/e2e/ledger:*")' --output=files | \
+                xargs -I {} sh -c 'cp {}.runfiles/__main__/report.xml ./bats-reports/$(basename {})_report.xml'
+      - store_test_results:
+          path: bats-reports
+
   # Compute code coverage and push the results to CodeCov.
   coverage:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,18 +219,18 @@ jobs:
           command: |
             TEST=$(circleci tests glob "tests/resiliency/kvstore/*.bats" | circleci tests split)
             A=($TEST)
-            B=${A[@]/#///}
-            C=${B[@]//kvstore\//kvstore:bats-resiliency-kvstore_}
-            D=${C[@]//.bats/}
+            B=(${A[@]/#///})
+            C=(${B[@]//kvstore\//kvstore:bats-resiliency-kvstore_})
+            D=(${C[@]//.bats/})
 
-            bazel test --test_output=errors --config=remote-cache $D
+            bazel test --test_output=errors --config=remote-cache ${D[@]}
             
             # Collect all test reports
             # NOTE: The combinaison of `xargs` and `sh -c` is insecure.
             #       The risks are acceptable on CI.
             E=$(printf " + \"%s\"" "${D[@]}")
             mkdir -p bats-reports
-            bazel cquery 'kind(.bats, ${E:2})' --output=files | \
+            bazel cquery "kind(.bats, ${E:2})" --output=files | \
               xargs -I {} sh -c 'cp {}.runfiles/__main__/report.xml ./bats-reports/$(basename {})_report.xml'
       - store_test_results:
           path: bats-reports
@@ -259,18 +259,18 @@ jobs:
           command: |
             TEST=$(circleci tests glob "tests/resiliency/ledger/*.bats" | circleci tests split)
             A=($TEST)
-            B=${A[@]/#///}
-            C=${B[@]//ledger\//ledger:bats-resiliency-ledger_}
-            D=${C[@]//.bats/}
+            B=(${A[@]/#///})
+            C=(${B[@]//ledger\//ledger:bats-resiliency-ledger_})
+            D=(${C[@]//.bats/})
             
-            bazel test --test_output=errors --config=remote-cache --config=bats-resiliency-ledger $D
+            bazel test --test_output=errors --config=remote-cache --config=bats-resiliency-ledger ${D[@]}
             
             # Collect all test reports
             # NOTE: The combinaison of `xargs` and `sh -c` is insecure.
             #       The risks are acceptable on CI.
             E=$(printf " + \"%s\"" "${D[@]}")
             mkdir -p bats-reports
-            bazel cquery 'kind(.bats, ${E:2})' --output=files | \
+            bazel cquery "kind(.bats, ${E:2})" --output=files | \
               xargs -I {} sh -c 'cp {}.runfiles/__main__/report.xml ./bats-reports/$(basename {})_report.xml'
       - store_test_results:
           path: bats-reports

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -206,13 +206,13 @@ container_pull(
 ### BATS SECTION ###
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-BAZEL_BATS_COMMIT_ID = "e85b43efc90133d5cd4ca807a811e9aa4006fb49"
+BAZEL_BATS_COMMIT_ID = "8ebd7d11cac3316e429b55d414667f320fb5eda3"
 
 git_repository(
     name = "bazel_bats",
     commit = BAZEL_BATS_COMMIT_ID,
-    remote = "https://github.com/filmil/bazel-bats",
-    shallow_since = "1677540706 -0800",
+    remote = "https://github.com/fmorency/bazel-bats",
+    shallow_since = "1680722748 -0400",
 )
 
 load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")

--- a/tests/e2e/kvstore/BUILD.bazel
+++ b/tests/e2e/kvstore/BUILD.bazel
@@ -8,6 +8,7 @@ bats_test_suite(
         "manual",
     ],
     uses_bats_assert = True,
+    bats_args = ["--formatter", "tap", "--report-formatter", "junit", "--output", "."],
     deps = [
         "//src/kvstore",
         "//src/many",

--- a/tests/e2e/ledger/BUILD.bazel
+++ b/tests/e2e/ledger/BUILD.bazel
@@ -16,6 +16,7 @@ bats_test_suite(
         "manual",
     ],
     uses_bats_assert = True,
+    bats_args = ["--formatter", "tap", "--report-formatter", "junit", "--output", "."],
     deps = [
         ":webauthn-state",
         "//src/idstore-export",
@@ -40,6 +41,7 @@ bats_test(
         "manual",
     ],
     uses_bats_assert = True,
+    bats_args = ["--formatter", "tap", "--report-formatter", "junit", "--output", "."],
     deps = [
         "//src/ledger",
         "//src/many",

--- a/tests/resiliency/kvstore/BUILD.bazel
+++ b/tests/resiliency/kvstore/BUILD.bazel
@@ -22,6 +22,7 @@ bats_test_suite(
         "manual",
     ],
     uses_bats_assert = True,
+    bats_args = ["--formatter", "tap", "--report-formatter", "junit", "--output", "."],
     deps = [
         "//docker:docker-kvstore-deps",
         "//src/kvstore",

--- a/tests/resiliency/ledger/BUILD.bazel
+++ b/tests/resiliency/ledger/BUILD.bazel
@@ -22,6 +22,7 @@ bats_test_suite(
         "manual",
     ],
     uses_bats_assert = True,
+    bats_args = ["--formatter", "tap", "--report-formatter", "junit", "--output", "."],
     deps = [
         "//docker:docker-ledger-deps",
         "//src/ledger",


### PR DESCRIPTION
Generate and collect bats test reports for display in the CircleCI `Tests` tab.

This PR uses my fork of the `bazel-bats` rule until https://github.com/filmil/bazel-bats/pull/22 is merged.

You can now see test results in the `Tests` tab.

We also have access to CircleCI Insight. See https://app.circleci.com/insights/github/liftedinit/many-rs/workflows/ci/tests?branch=pull/355

Resiliency test example in https://app.circleci.com/pipelines/github/liftedinit/many-rs/1487

Fixes #332 

![2023-04-05_15-48](https://user-images.githubusercontent.com/1102868/230400343-100a0e33-7c78-4144-83b1-aaa8efd427f2.png)
![2023-04-05_15-48_1](https://user-images.githubusercontent.com/1102868/230400358-6008935d-3790-42f4-9482-8a9c3ce575fe.png)