### PR TITLE
fix: when loading migrations, activate them properly at the height

### DIFF
--- a/src/many-abci/src/module.rs
+++ b/src/many-abci/src/module.rs
@@ -175,7 +175,7 @@ impl<C: Client + Send + Sync> r#async::AsyncModuleBackend for AbciBlockchainModu
                 None => return Ok(StatusReturn::Unknown),
             };
 
-            tracing::warn!("result: {}", hex::encode(&tx_result_data));
+            tracing::debug!("result: {}", hex::encode(&tx_result_data));
             Ok(StatusReturn::Done {
                 response: Box::new(
                     encode_cose_sign1_from_response(

--- a/src/many-ledger/src/storage/migrations.rs
+++ b/src/many-ledger/src/storage/migrations.rs
@@ -12,7 +12,7 @@ impl LedgerStorage {
         //       It is currently NOT possible to run new code in non-blockchain mode when loading an existing DB
         self.migrations = migration_config
             .map_or_else(MigrationSet::empty, |config| {
-                LedgerMigrations::load(&MIGRATIONS, config, 0)
+                LedgerMigrations::load(&MIGRATIONS, config, self.get_height()?)
             })
             .map_err(ManyError::unknown)?; // TODO: Custom error
 

--- a/src/many-ledger/src/storage/migrations.rs
+++ b/src/many-ledger/src/storage/migrations.rs
@@ -12,7 +12,11 @@ impl LedgerStorage {
         //       It is currently NOT possible to run new code in non-blockchain mode when loading an existing DB
         self.migrations = migration_config
             .map_or_else(MigrationSet::empty, |config| {
-                LedgerMigrations::load(&MIGRATIONS, config, self.get_height()?)
+                LedgerMigrations::load(
+                    &MIGRATIONS,
+                    config,
+                    self.get_height().map_err(|e| e.to_string())?,
+                )
             })
             .map_err(ManyError::unknown)?; // TODO: Custom error
 

--- a/src/many-ledger/src/storage/migrations.rs
+++ b/src/many-ledger/src/storage/migrations.rs
@@ -12,11 +12,7 @@ impl LedgerStorage {
         //       It is currently NOT possible to run new code in non-blockchain mode when loading an existing DB
         self.migrations = migration_config
             .map_or_else(MigrationSet::empty, |config| {
-                LedgerMigrations::load(
-                    &MIGRATIONS,
-                    config,
-                    self.get_height().map_err(|e| e.to_string())?,
-                )
+                LedgerMigrations::load(&MIGRATIONS, config, 0)
             })
             .map_err(ManyError::unknown)?; // TODO: Custom error
 

--- a/src/many-migration/src/lib.rs
+++ b/src/many-migration/src/lib.rs
@@ -333,7 +333,7 @@ impl<'a, T, E> Migration<'a, T, E> {
             self.active = (self.metadata.block_height
                 ..self.metadata.upper_block_height.unwrap_or(u64::MAX))
                 .contains(&height);
-        } else if height >= self.metadata.block_height {
+        } else if height > self.metadata.block_height {
             self.active = true;
         }
     }
@@ -566,8 +566,6 @@ impl<'a, T, E> MigrationSet<'a, T, E> {
         for v in inner.values_mut().filter(|m| m.is_enabled()) {
             v.set_active_at_height(height);
         }
-
-        tracing::info!("h = {}, inner = {:?}", height, inner);
 
         Ok(Self { inner })
     }

--- a/src/many-migration/src/lib.rs
+++ b/src/many-migration/src/lib.rs
@@ -555,6 +555,8 @@ impl<'a, T, E> MigrationSet<'a, T, E> {
             let _ = v.activate_at_height(height);
         }
 
+        tracing::info!("h = {}, inner = {:?}", height, inner);
+
         Ok(Self { inner })
     }
 

--- a/src/many-migration/src/lib.rs
+++ b/src/many-migration/src/lib.rs
@@ -333,7 +333,7 @@ impl<'a, T, E> Migration<'a, T, E> {
             self.active = (self.metadata.block_height
                 ..self.metadata.upper_block_height.unwrap_or(u64::MAX))
                 .contains(&height);
-        } else if height > self.metadata.block_height {
+        } else if height >= self.metadata.block_height {
             self.active = true;
         }
     }

--- a/src/many-migration/tests/migrations.rs
+++ b/src/many-migration/tests/migrations.rs
@@ -438,6 +438,40 @@ fn migration_config() {
 }
 
 #[test]
+fn migration_config_at_height() {
+    let config = MigrationConfig::default()
+        .with_migration_opts(&A, Metadata::enabled(5))
+        .with_migration(&B)
+        .with_migration_opts(&C, Metadata::disabled(100));
+
+    assert_eq!(
+        config,
+        [
+            (&A, Metadata::enabled(5)),
+            (&B, Metadata::enabled(0)),
+            (&C, Metadata::disabled(100))
+        ]
+        .into()
+    );
+
+    let migration_set = MigrationSet::load(&SOME_MANY_RS_MIGRATIONS, config.clone(), 105).unwrap();
+    assert!(migration_set.is_enabled(&A));
+    assert!(migration_set.is_active(&A));
+    assert!(migration_set.is_enabled(&B));
+    assert!(migration_set.is_active(&B));
+    assert!(!migration_set.is_enabled(&C));
+    assert!(!migration_set.is_active(&C));
+
+    let migration_set = MigrationSet::load(&SOME_MANY_RS_MIGRATIONS, config, 5).unwrap();
+    assert!(migration_set.is_enabled(&A));
+    assert!(migration_set.is_active(&A));
+    assert!(migration_set.is_enabled(&B));
+    assert!(migration_set.is_active(&B));
+    assert!(!migration_set.is_enabled(&C));
+    assert!(!migration_set.is_active(&C));
+}
+
+#[test]
 fn strict_config_one() {
     let config = MigrationConfig::default()
         .with_migration_opts(&A, Metadata::enabled(5))

--- a/src/many-migration/tests/migrations.rs
+++ b/src/many-migration/tests/migrations.rs
@@ -454,6 +454,14 @@ fn migration_config_at_height() {
         .into()
     );
 
+    let migration_set = MigrationSet::load(&SOME_MANY_RS_MIGRATIONS, config.clone(), 1).unwrap();
+    assert!(migration_set.is_enabled(&A));
+    assert!(!migration_set.is_active(&A));
+    assert!(migration_set.is_enabled(&B));
+    assert!(migration_set.is_active(&B));
+    assert!(!migration_set.is_enabled(&C));
+    assert!(!migration_set.is_active(&C));
+
     let migration_set = MigrationSet::load(&SOME_MANY_RS_MIGRATIONS, config.clone(), 105).unwrap();
     assert!(migration_set.is_enabled(&A));
     assert!(migration_set.is_active(&A));

--- a/tests/resiliency/ledger/token_migration.bats
+++ b/tests/resiliency/ledger/token_migration.bats
@@ -170,14 +170,19 @@ function teardown() {
 
 @test "$SUITE: Token creation migration is properly initialized when resetting the node" {
     check_consistency --pem=1 --balance=1000000 --id="$(identity 1)" 8000 8001 8002 8003
+    call_ledger --pem=1 --port=8000 token info ${MFX_ADDRESS}
+    assert_output --partial "Invalid method name"
+
     wait_for_block 30
-    make -f $MAKEFILE stop-single-node-1
-    call_ledger --pem=1 --port=8000 token mint ${SYMBOL} ''\''{"'$(identity 2)'": 123, "'$(identity 3)'": 456}'\'''
+    for port in 8000 8001 8002 8003; do
+        call_ledger --pem=1 --port=${port} token info ${MFX_ADDRESS}
+        assert_output --partial "name: \"Manifest Network Token\""
+    done
 
+    make -f $MAKEFILE stop-single-node-0
     wait_for_block 40
-    make -f $MAKEFILE start-single-node-1
+    make -f $MAKEFILE start-single-node-0
 
-    wait_for_block 50
-    check_consistency --pem=1 --balance=123 --id="$(identity 2)" 8000 8001 8002 8003
-    check_consistency --pem=1 --balance=456 --id="$(identity 3)" 8000 8001 8002 8003
+    call_ledger --pem=1 --port=8000 token info ${MFX_ADDRESS}
+    assert_output --partial "Invalid method name"
 }

--- a/tests/resiliency/ledger/token_migration.bats
+++ b/tests/resiliency/ledger/token_migration.bats
@@ -167,3 +167,17 @@ function teardown() {
     # Creation successful
     create_token --pem=1 --port=8000
 }
+
+@test "$SUITE: Token creation migration is properly initialized when resetting the node" {
+    check_consistency --pem=1 --balance=1000000 --id="$(identity 1)" 8000 8001 8002 8003
+    wait_for_block 30
+    make -f $MAKEFILE stop-single-node-1
+    call_ledger --pem=1 --port=8000 token mint ${SYMBOL} ''\''{"'$(identity 2)'": 123, "'$(identity 3)'": 456}'\'''
+
+    wait_for_block 40
+    make -f $MAKEFILE start-single-node-1
+
+    wait_for_block 50
+    check_consistency --pem=1 --balance=123 --id="$(identity 2)" 8000 8001 8002 8003
+    check_consistency --pem=1 --balance=456 --id="$(identity 3)" 8000 8001 8002 8003
+}


### PR DESCRIPTION
Previously, the activation only happened at the height itself. The `initialize` function would be called at the correct height. If the migration config was loaded at a height after the migration, the migration would be enabled but inactive.

This PR tries to address this bug.

Fixes #359 