### PR TITLE
fix: collect bats test report on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,7 @@ jobs:
             bazel test --test_output=errors --config=remote-cache ${D[@]}
       - run:
           name: collect test reports
+          when: always
           command: |
             # Collect all test reports
             # NOTE: The combinaison of `xargs` and `sh -c` is insecure.
@@ -270,6 +271,7 @@ jobs:
             bazel test --test_output=errors --config=remote-cache --config=bats-resiliency-ledger ${D[@]}
       - run:
           name: collect test reports
+          when: always
           command: |
             # Collect all test reports
             # NOTE: The combinaison of `xargs` and `sh -c` is insecure.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,9 +222,12 @@ jobs:
             B=(${A[@]/#///})
             C=(${B[@]//kvstore\//kvstore:bats-resiliency-kvstore_})
             D=(${C[@]//.bats/})
+            echo "export D=($D)" >> "$BASH_ENV"
 
             bazel test --test_output=errors --config=remote-cache ${D[@]}
-            
+      - run:
+          name: collect test reports
+          command: |
             # Collect all test reports
             # NOTE: The combinaison of `xargs` and `sh -c` is insecure.
             #       The risks are acceptable on CI.
@@ -262,9 +265,12 @@ jobs:
             B=(${A[@]/#///})
             C=(${B[@]//ledger\//ledger:bats-resiliency-ledger_})
             D=(${C[@]//.bats/})
+            echo "export D=($D)" >> "$BASH_ENV"
             
             bazel test --test_output=errors --config=remote-cache --config=bats-resiliency-ledger ${D[@]}
-            
+      - run:
+          name: collect test reports
+          command: |
             # Collect all test reports
             # NOTE: The combinaison of `xargs` and `sh -c` is insecure.
             #       The risks are acceptable on CI.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
             B=(${A[@]/#///})
             C=(${B[@]//kvstore\//kvstore:bats-resiliency-kvstore_})
             D=(${C[@]//.bats/})
-            echo "export D=($D)" >> "$BASH_ENV"
+            echo "export D=(${D[@]})" >> "$BASH_ENV"
 
             bazel test --test_output=errors --config=remote-cache ${D[@]}
       - run:
@@ -266,7 +266,7 @@ jobs:
             B=(${A[@]/#///})
             C=(${B[@]//ledger\//ledger:bats-resiliency-ledger_})
             D=(${C[@]//.bats/})
-            echo "export D=($D)" >> "$BASH_ENV"
+            echo "export D=(${D[@]})" >> "$BASH_ENV"
             
             bazel test --test_output=errors --config=remote-cache --config=bats-resiliency-ledger ${D[@]}
       - run:


### PR DESCRIPTION
Collect test reports even on failure.

See https://app.circleci.com/pipelines/github/liftedinit/many-rs/1727/workflows/a51c15b8-bfa9-48b3-90fb-2c66acce4e5d/jobs/4311/tests for an example.

This PR makes it easier to retrieve the real underlying error of a bats test failure in CI.

Note that the resiliency test failure of this PR is expected.