### PR TITLE
feat: allow token owner to mint/burn

### DIFF
--- a/src/many-ledger/src/error.rs
+++ b/src/many-ledger/src/error.rs
@@ -38,6 +38,7 @@ define_attribute_many_error!(
         3: pub fn missing_funds(symbol, amount, balance) => "Unable to burn, missing funds: {amount} > {balance} {symbol}.",
         4: pub fn unable_to_distribute_zero(symbol) => "The mint/burn distribution contains zero for {symbol}.",
         5: pub fn partial_burn_disabled() => "Partial burns are disabled.",
+        6: pub fn no_token_owner() => "Token doesn't have an owner."
     }
 );
 

--- a/src/many-ledger/test-utils/src/cucumber.rs
+++ b/src/many-ledger/test-utils/src/cucumber.rs
@@ -96,7 +96,7 @@ impl SomeId {
 #[derive(Debug, Default, Eq, Parameter, PartialEq)]
 #[param(
     name = "error",
-    regex = "(unauthorized)|(missing permission)|(immutable)|(invalid sender)|(unable to distribute zero)|(partial burn disabled)|(missing funds)|(over maximum)|(ticker exists)|(invalid ticker length)"
+    regex = "(unauthorized)|(missing permission)|(immutable)|(invalid sender)|(unable to distribute zero)|(partial burn disabled)|(missing funds)|(over maximum)|(ticker exists)|(invalid ticker length)|(no token owner)"
 )]
 pub enum SomeError {
     #[default]
@@ -110,6 +110,7 @@ pub enum SomeError {
     OverMaximum,
     TickerExists,
     InvalidTickerLength,
+    NoTokenOwner,
 }
 
 impl FromStr for SomeError {
@@ -127,6 +128,7 @@ impl FromStr for SomeError {
             "over maximum" => Self::OverMaximum,
             "ticker exists" => Self::TickerExists,
             "invalid ticker length" => Self::InvalidTickerLength,
+            "no token owner" => Self::NoTokenOwner,
             _ => unimplemented!(),
         })
     }
@@ -177,6 +179,7 @@ impl SomeError {
             SomeError::OverMaximum => error::over_maximum_supply("", "", "").code(),
             SomeError::TickerExists => error::ticker_exists("").code(),
             SomeError::InvalidTickerLength => error::invalid_ticker_length("").code(),
+            SomeError::NoTokenOwner => error::no_token_owner().code(),
         }
     }
 }

--- a/src/many-ledger/tests/features/ledger_mintburn/burn.feature
+++ b/src/many-ledger/tests/features/ledger_mintburn/burn.feature
@@ -15,12 +15,25 @@ Scenario: Burn tokens
 	And the memo is "Barfoo"
 
 @tokens
-Scenario: Burn tokens as random/anonymous
+Scenario: Burn tokens as random/anonymous, token owner present
 	Given a default token owned by myself
 	And a distribution of 12 tokens to id 2
 	And a distribution of 23 tokens to id 3
 	Then burning as random fails with invalid sender
 	Then burning as anonymous fails with invalid sender
+	Then id 1 has 123 tokens
+	And id 2 has 456 tokens
+	And id 3 has 789 tokens
+	And the circulating supply is 1368 tokens
+	And the total supply is 1368 tokens
+
+@tokens
+Scenario: Burn tokens as random/anonymous, token owner absent
+	Given a default token owned by no one
+	And a distribution of 12 tokens to id 2
+	And a distribution of 23 tokens to id 3
+	Then burning as random fails with no token owner
+	Then burning as anonymous fails with no token owner
 	Then id 1 has 123 tokens
 	And id 2 has 456 tokens
 	And id 3 has 789 tokens

--- a/src/many-ledger/tests/features/ledger_mintburn/burn.feature
+++ b/src/many-ledger/tests/features/ledger_mintburn/burn.feature
@@ -15,11 +15,10 @@ Scenario: Burn tokens
 	And the memo is "Barfoo"
 
 @tokens
-Scenario: Burn tokens as myself/random/anonymous
+Scenario: Burn tokens as random/anonymous
 	Given a default token owned by myself
 	And a distribution of 12 tokens to id 2
 	And a distribution of 23 tokens to id 3
-	Then burning as myself fails with invalid sender
 	Then burning as random fails with invalid sender
 	Then burning as anonymous fails with invalid sender
 	Then id 1 has 123 tokens
@@ -27,6 +26,20 @@ Scenario: Burn tokens as myself/random/anonymous
 	And id 3 has 789 tokens
 	And the circulating supply is 1368 tokens
 	And the total supply is 1368 tokens
+
+@tokens
+Scenario: Burn tokens as token owner
+	Given a default token owned by myself
+	And a distribution of 12 tokens to id 2
+	And a distribution of 23 tokens to id 3
+	And a memo "Barfoo"
+	When I burn the tokens as myself
+	Then id 1 has 123 tokens
+	And id 2 has 444 tokens
+	And id 3 has 766 tokens
+	And the circulating supply is 1333 tokens
+	And the total supply is 1333 tokens
+	And the memo is "Barfoo"
 
 @tokens
 Scenario: Unable to burn zero

--- a/src/many-ledger/tests/features/ledger_mintburn/mint.feature
+++ b/src/many-ledger/tests/features/ledger_mintburn/mint.feature
@@ -18,12 +18,25 @@ Scenario: Mint new tokens as token identity
 	And the memo is "Foobar"
 
 @tokens
-Scenario: Mint new tokens as random/anonymous
+Scenario: Mint new tokens as random/anonymous, token owner present
 	Given a default token owned by myself
 	And a distribution of 1000 tokens to id 10
 	And a distribution of 250 tokens to id 11
 	Then minting as random fails with invalid sender
 	Then minting as anonymous fails with invalid sender
+	Then id 1 has 123 tokens
+	And id 2 has 456 tokens
+	And id 3 has 789 tokens
+	And the circulating supply is 1368 tokens
+	And the total supply is 1368 tokens
+
+@tokens
+Scenario: Mint new tokens as random/anonymous, token owner absent
+	Given a default token owned by no one
+	And a distribution of 1000 tokens to id 10
+	And a distribution of 250 tokens to id 11
+	Then minting as random fails with no token owner
+	Then minting as anonymous fails with no token owner
 	Then id 1 has 123 tokens
 	And id 2 has 456 tokens
 	And id 3 has 789 tokens

--- a/src/many-ledger/tests/features/ledger_mintburn/mint.feature
+++ b/src/many-ledger/tests/features/ledger_mintburn/mint.feature
@@ -18,11 +18,10 @@ Scenario: Mint new tokens as token identity
 	And the memo is "Foobar"
 
 @tokens
-Scenario: Mint new tokens as myself/random/anonymous
+Scenario: Mint new tokens as random/anonymous
 	Given a default token owned by myself
 	And a distribution of 1000 tokens to id 10
 	And a distribution of 250 tokens to id 11
-	Then minting as myself fails with invalid sender
 	Then minting as random fails with invalid sender
 	Then minting as anonymous fails with invalid sender
 	Then id 1 has 123 tokens
@@ -30,6 +29,23 @@ Scenario: Mint new tokens as myself/random/anonymous
 	And id 3 has 789 tokens
 	And the circulating supply is 1368 tokens
 	And the total supply is 1368 tokens
+
+@tokens
+Scenario: Mint new tokens as token owner
+	Given a default token owned by myself
+	And a distribution of 1000 tokens to id 10
+	And a distribution of 250 tokens to id 11
+	And a memo "Foobar"
+	When I mint the tokens as myself
+	Then id 1 has 123 tokens
+	And id 2 has 456 tokens
+	And id 3 has 789 tokens
+	And id 10 has 1000 tokens
+	And id 11 has 250 tokens
+	And myself has 0 tokens
+	And the circulating supply is 2618 tokens
+	And the total supply is 2618 tokens
+	And the memo is "Foobar"
 
 @tokens
 Scenario: Unable to mint zero

--- a/staging/ledger_state.json5
+++ b/staging/ledger_state.json5
@@ -76,6 +76,8 @@
    "mqbfbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wiaaaaqnz": {
      name: "Manifest Network Token",
      decimals: 9,
+     owner: null,
+     maximum: null,
    }
   },
 

--- a/tests/resiliency/ledger/token_migration.bats
+++ b/tests/resiliency/ledger/token_migration.bats
@@ -141,6 +141,7 @@ function teardown() {
         refute_output --partial "Some memo"
     done
 
+    # Mint tokens as the token identity
     call_ledger --pem=1 --port=8000 token mint ${SYMBOL} ''\''{"'$(identity 2)'": 123, "'$(identity 3)'": 456}'\'''
     for port in 8000 8001 8002 8003; do
         call_ledger --port=${port} token info "${SYMBOL}"
@@ -148,11 +149,28 @@ function teardown() {
         assert_output --regexp "circulating:.*(.*579,.*)"
     done
 
+    # Burn tokens as the token identity
     call_ledger --pem=1 --port=8000 token burn ${SYMBOL} ''\''{"'$(identity 2)'": 122, "'$(identity 3)'": 455}'\''' --error-on-under-burn
     for port in 8000 8001 8002 8003; do
         call_ledger --port=${port} token info "${SYMBOL}"
         assert_output --regexp "total:.*(.*2,.*)"
         assert_output --regexp "circulating:.*(.*2,.*)"
+    done
+
+    # Mint tokens as the token owner
+    call_ledger --pem=2 --port=8000 token mint ${SYMBOL} ''\''{"'$(identity 2)'": 123, "'$(identity 3)'": 456}'\'''
+    for port in 8000 8001 8002 8003; do
+        call_ledger --port=${port} token info "${SYMBOL}"
+        assert_output --regexp "total:.*(.*581,.*)"
+        assert_output --regexp "circulating:.*(.*581,.*)"
+    done
+
+    # Burn tokens as the token owner
+    call_ledger --pem=2 --port=8000 token burn ${SYMBOL} ''\''{"'$(identity 2)'": 122, "'$(identity 3)'": 455}'\''' --error-on-under-burn
+    for port in 8000 8001 8002 8003; do
+        call_ledger --port=${port} token info "${SYMBOL}"
+        assert_output --regexp "total:.*(.*4,.*)"
+        assert_output --regexp "circulating:.*(.*4,.*)"
     done
 }
 


### PR DESCRIPTION
Only the token identity is allowed to mint/burn (any) tokens.

This PR adds support for a token owner to mint/burn the given token.

Fixes #372 