### PR TITLE
ci: add manual release support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     parameters:
       os:
         type: string
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     executor: << parameters.os >>
@@ -57,7 +57,7 @@ jobs:
                     --test_output=errors \
                     --test_env=PKCS11_SOFTHSM2_MODULE \
                     --test_env=SOFTHSM2_CONF \
-                    << parameters.bazel_extra_args >> \
+                    << parameters.bazel_linkopt >> \
                     -- //...
       - when:
           condition:
@@ -78,7 +78,7 @@ jobs:
     parameters:
       os:
         type: string
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     executor: << parameters.os >>
@@ -98,7 +98,7 @@ jobs:
           steps:
             - run_bats_e2e_tests:
                 os: << parameters.os >>
-                bazel_extra_args: ""
+                bazel_linkopt: ""
       - when:
           condition:
             not:
@@ -124,7 +124,7 @@ jobs:
     parameters:
       os:
         type: string
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     executor: << parameters.os >>
@@ -141,39 +141,39 @@ jobs:
               --test_env=PKCS11_SOFTHSM2_MODULE \
               --test_env=SOFTHSM2_CONF \
               --combined_report=lcov \
-              << parameters.bazel_extra_args >> \
+              << parameters.bazel_linkopt >> \
               -- //...
       - codecov/upload:
           file: bazel-out/_coverage/_coverage_report.dat
-
-  # Create a developer's release build. Useful to test PRs on development networks.
-  dev_release:
-    parameters:
-      os:
-        type: string
-    executor: << parameters.os >>
-    steps:
-      - checkout
-      - build_release:
-          release_id: ${CIRCLE_PR_NUMBER}
-      - store_artifacts:
-          path: artifacts
 
   # Create a release build
   create:
     parameters:
       os:
         type: string
+      release_id:
+        type: string
+        default: "RELEASE"
+      bazel_args:
+        type: string
+        default: ""
+      bazel_linkopt:
+        type: string
+        default: *bazel_linux_linkopt
     executor: << parameters.os >>
     steps:
       - checkout
       - build_release:
-          release_id: ${CIRCLE_TAG}
+          release_id: << parameters.release_id >>
+          bazel_args: << parameters.bazel_args >>
+          bazel_linkopt: << parameters.bazel_linkopt >>
       - persist_to_workspace:
           root: artifacts
           paths:
             - "*.tar.gz"
             - "*.txt"
+      - store_artifacts:
+          path: artifacts
 
   # Push a (pre-)release build to GitHub
   publish:
@@ -218,7 +218,7 @@ jobs:
   publish_nightly_docker:
     executor: linux2204_machine
     parameters:
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     steps:
@@ -228,20 +228,20 @@ jobs:
           name: publish nightly docker images
           command: |
               bazel run --jobs=$(nproc) \
-                << parameters.bazel_extra_args >> \
+                << parameters.bazel_linkopt >> \
                 --config=remote-cache //docker:many-abci-push-docker 
               bazel run --jobs=$(nproc) \
-                << parameters.bazel_extra_args >> \
+                << parameters.bazel_linkopt >> \
                 --config=remote-cache //docker:many-kvstore-push-docker
               bazel run --jobs=$(nproc) \
-                << parameters.bazel_extra_args >> \
+                << parameters.bazel_linkopt >> \
                 --config=remote-cache //docker:many-ledger-push-docker
 
   # Perform kvstore resiliency testing
   kvstore_resiliency_tests:
     executor: linux2204_machine
     parameters:
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     parallelism: 4
@@ -257,7 +257,7 @@ jobs:
             D=(${C[@]//.bats/})
             echo "export D=(${D[@]})" >> "$BASH_ENV"
 
-            bazel test << parameters.bazel_extra_args >> --test_output=errors \
+            bazel test << parameters.bazel_linkopt >> --test_output=errors \
               --config=remote-cache ${D[@]}
       - run:
           name: collect test reports
@@ -287,14 +287,14 @@ jobs:
       test_name:
         type: string
         default: ""
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     steps:
       - checkout
       - run:
           name: running single tests
-          command: bazel test << parameters.bazel_extra_args >> --test_output=errors \
+          command: bazel test << parameters.bazel_linkopt >> --test_output=errors \
             --config=remote-cache \
             //tests/resiliency/kvstore:bats-resiliency-kvstore_<< parameters.test_name >>
 
@@ -302,7 +302,7 @@ jobs:
   ledger_resiliency_tests:
     executor: linux2204_machine
     parameters:
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     parallelism: 4
@@ -318,7 +318,7 @@ jobs:
             D=(${C[@]//.bats/})
             echo "export D=(${D[@]})" >> "$BASH_ENV"
             
-            bazel test << parameters.bazel_extra_args >> --test_output=errors \
+            bazel test << parameters.bazel_linkopt >> --test_output=errors \
               --config=remote-cache \
               --config=bats-resiliency-ledger ${D[@]}
       - run:
@@ -349,14 +349,14 @@ jobs:
       test_name:
         type: string
         default: ""
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     steps:
       - checkout
       - run:
           name: running single tests
-          command: bazel test << parameters.bazel_extra_args >> --test_output=errors \
+          command: bazel test << parameters.bazel_linkopt >> --test_output=errors \
             --config=remote-cache \
             --config=bats-resiliency-ledger \
             //tests/resiliency/ledger:bats-resiliency-ledger_<< parameters.test_name >>
@@ -427,10 +427,13 @@ commands:
     parameters:
       release_id:
         type: string
-        default: dev
-      bazel_extra_args:
+        default: "RELEASE"
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
+      bazel_args:
+        type: string
+        default: ""
     steps:
       - detect/init
       - run: mkdir -p artifacts
@@ -439,7 +442,7 @@ commands:
           command: |
             bazel build -c opt \
               --linkopt=-Wl,--strip-all \
-              << parameters.bazel_extra_args >> \
+              << parameters.bazel_linkopt >> << parameters.bazel_args >> \
               --config=remote-cache \
               //:many-rs-tar
             bazel cquery :many-rs-tar --output=files -c opt | xargs -n 1 -I % mv % artifacts/many-rs_<< parameters.release_id >>_${CIRCLE_SHA1}_${OSD_ID}_${OSD_VERSION}.tar.gz
@@ -452,22 +455,22 @@ commands:
     parameters:
       os:
         type: string
-      bazel_extra_args:
+      bazel_linkopt:
         type: string
         default: *bazel_linux_linkopt
     steps:
       - run:
           name: running bats e2e tests
           command: |
-            bazel test << parameters.bazel_extra_args >> --test_output=errors \
+            bazel test << parameters.bazel_linkopt >> --test_output=errors \
               --config=all-features \
               --config=remote-cache //tests/e2e/kvstore:bats-e2e-kvstore
-            bazel test << parameters.bazel_extra_args >> --test_output=errors \
+            bazel test << parameters.bazel_linkopt >> --test_output=errors \
               --config=all-features \
               --config=remote-cache //tests/e2e/ledger:bats-e2e-ledger
             
             # --disable_token_sender_check needs to be disabled for the token sender check test
-            bazel test << parameters.bazel_extra_args >> --test_output=errors \
+            bazel test << parameters.bazel_linkopt >> --test_output=errors \
               --balance_testing \
               --migration_testing \
               --config=remote-cache //tests/e2e/ledger:bats-e2e-ledger-token-sender-check
@@ -488,6 +491,22 @@ parameters:
   test_name:
     type: string
     default: ""
+
+  manual_release:
+    type: boolean
+    default: false
+
+  release_id:
+    type: string
+    default: "MANUAL_RELEASE"
+
+  bazel_args:
+    type: string
+    default: ""
+
+  bazel_linkopt:
+    type: string
+    default: *bazel_linux_linkopt
 
 workflows:
   ci:
@@ -522,7 +541,7 @@ workflows:
               os: [linux2204]
           requires:
             - lint-test-build-v<< matrix.os >>
-      - dev_release:
+      - create:
           pre-steps:
             - install-deps:
                 os: << matrix.os >>
@@ -530,6 +549,7 @@ workflows:
           matrix:
             parameters:
               os: [linux2204]
+              release_id: ["${CIRCLE_PR_NUMBER}"]
           requires:
             - lint-test-build-v<< matrix.os >>
   release:
@@ -545,6 +565,7 @@ workflows:
           matrix:
             parameters:
               os: [linux2204]
+              release_id: ["${CIRCLE_TAG}"]
           filters:
             branches:
               ignore: /.*/
@@ -582,6 +603,25 @@ workflows:
               only:
                 - /^\d+\.\d+\.\d+-.*-rc.*$/         # e.g., 0.1.1-alpha-rc1, 1.3.4-beta-rc4
                 - /^\d+\.\d+\.\d+-pre.*$/           # e.g., 0.1.1-prealpha-3, 1.5.6-prealpha-8
+
+  manual_release:
+    when:
+      and:
+        - equal: [ api, << pipeline.trigger_source >> ]
+        - equal: [ true, << pipeline.parameters.manual_release >> ]
+    jobs:
+      - create:
+          pre-steps:
+            - install-deps:
+                os: << matrix.os >>
+          name: create-v<< matrix.os >>
+          matrix:
+            parameters:
+              os: [linux2204]
+              release_id: [<< pipeline.parameters.release_id >>]
+              bazel_args: [<< pipeline.parameters.bazel_args >>]
+              bazel_linkopt: [<< pipeline.parameters.bazel_linkopt >>]
+
   security:
     when:
       and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,11 +466,11 @@ commands:
               --config=all-features \
               --config=remote-cache //tests/e2e/ledger:bats-e2e-ledger
             
-            # --disable_token_sender_check needs to be disabled for the token tests
+            # --disable_token_sender_check needs to be disabled for the token sender check test
             bazel test << parameters.bazel_extra_args >> --test_output=errors \
               --balance_testing \
               --migration_testing \
-              --config=remote-cache //tests/e2e/ledger:bats-e2e-ledger-tokens
+              --config=remote-cache //tests/e2e/ledger:bats-e2e-ledger-token-sender-check
 
 parameters:
   run_resiliency:

--- a/tests/e2e/ledger/BUILD.bazel
+++ b/tests/e2e/ledger/BUILD.bazel
@@ -9,7 +9,7 @@ bats_test_suite(
     name = "bats-e2e-ledger",
     srcs = glob(
         include = ["*.bats"],
-        exclude = ["tokens.bats"],
+        exclude = ["token_migration_sender_verification.bats"],
     ),
     tags = [
         "exclusive",
@@ -29,12 +29,12 @@ bats_test_suite(
     ],
 )
 
-# TODO: Transition.
+# TODO: Toggle this test based on the presence of the --disable_token_sender_check flag
 # Can't run with --disable_token_sender_check
 bats_test(
-    name = "bats-e2e-ledger-tokens",
+    name = "bats-e2e-ledger-token-sender-check",
     srcs = [
-        "tokens.bats",
+        "token_migration_sender_verification.bats",
     ],
     tags = [
         "exclusive",

--- a/tests/e2e/ledger/token_migration_sender_verification.bats
+++ b/tests/e2e/ledger/token_migration_sender_verification.bats
@@ -1,0 +1,55 @@
+# e2e tests for the token feature set
+# The Token Migration needs to be active for this feature set to be enabled.
+
+GIT_ROOT="$BATS_TEST_DIRNAME/../../../"
+MFX_ADDRESS=mqbfbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wiaaaaqnz
+START_BALANCE=100000000000
+MIGRATION_ROOT="$GIT_ROOT/staging/ledger_migrations.json"
+load '../../test_helper/load'
+load '../../test_helper/ledger'
+
+function setup() {
+    load "test_helper/bats-assert/load"
+    load "test_helper/bats-support/load"
+
+    mkdir "$BATS_TEST_ROOTDIR"
+
+    skip_if_missing_background_utilities
+
+    jq '(.migrations[] | select(.name == "Token Migration")).block_height |= 0 |
+        (.migrations[] | select(.name == "Token Migration")).disabled |= empty' \
+        "$MIGRATION_ROOT" > "$BATS_TEST_ROOTDIR/migrations.json"
+
+    # Dummy image
+     echo -n -e '\x68\x65\x6c\x6c\x6f' > "$BATS_TEST_ROOTDIR/image.png"
+
+    # Activating the Token Migration from block 0 will modify the ledger staging hash
+    # The symbol metadata will be stored in the DB
+    cp "$GIT_ROOT/staging/ledger_state.json5" "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # The MFX address in the staging file is now `identity 1`
+    sed -i.bak 's/'${MFX_ADDRESS}'/'$(subresource 1 1)'/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Make `identity 1` the token identity
+    sed -i.bak 's/token_identity: ".*"/token_identity: "'"$(identity 1)"'"/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Use token identity subresource 0 as the first token symbol
+    sed -i.bak 's/token_next_subresource: 2/token_next_subresource: 0/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    # Skip hash check
+    sed -i.bak 's/hash/\/\/hash/' "$BATS_TEST_ROOTDIR/ledger_state.json5"
+
+    start_ledger --state="$BATS_TEST_ROOTDIR/ledger_state.json5" \
+        --pem "$(pem 0)" \
+        --balance-only-for-testing="$(identity 8):$START_BALANCE:$(subresource 1 1)" \
+        --migrations-config "$BATS_TEST_ROOTDIR/migrations.json"
+}
+
+function teardown() {
+    stop_background_run
+}
+
+@test "$SUITE: can't create as identity 2" {
+    create_token --pem=2 --error=invalid_sender --port=8000
+}
+

--- a/tests/e2e/ledger/tokens.bats
+++ b/tests/e2e/ledger/tokens.bats
@@ -102,10 +102,6 @@ function teardown() {
     create_token --error=anon --port=8000
 }
 
-@test "$SUITE: can't create as identity 2" {
-    create_token --pem=2 --error=invalid_sender --port=8000
-}
-
 @test "$SUITE: can update token" {
     create_token --pem=1 --port=8000
 


### PR DESCRIPTION
DRY release code.

Add the ability to create a manual release with custom arguments/features.

Trigger a manual CI pipeline with

`manual_release` : boolean : true
`bazel_args` : string : extra argument to pass to Bazel, e.g., `--disable_token_sender_check`
`release_id` : string : some string identifying the release and added to the package file name


Fixes #371