### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -121,12 +121,11 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "asn1"
-version = "0.13.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2affba5e62ee09eeba078f01a00c4aed45ac4287e091298eccbb0d4802efbdc5"
+checksum = "28c19b9324de5b815b6487e0f8098312791b09de0dbf3d5c2db1fe2d95bab973"
 dependencies = [
  "asn1_derive",
- "chrono",
 ]
 
 [[package]]
@@ -170,13 +169,13 @@ dependencies = [
 
 [[package]]
 name = "asn1_derive"
-version = "0.13.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfab79c195875e5aef2bd20b4c8ed8d43ef9610bcffefbbcf66f88f555cc78af"
+checksum = "a045c3ccad89f244a86bd1e6cf1a7bf645296e7692698b056399b6efd4639407"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -283,7 +282,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -300,7 +299,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -395,9 +394,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -411,7 +410,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18b3d30abb74120a9d5267463b9e0045fdccc4dd152e7249d966612dc1721384"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "serde",
  "serde_json",
 ]
@@ -663,8 +662,9 @@ checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -673,13 +673,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half 1.8.2",
@@ -760,7 +762,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1008,7 +1010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1257,7 +1259,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1274,15 +1276,16 @@ checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.6"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der",
  "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
  "signature 2.1.0",
+ "spki",
 ]
 
 [[package]]
@@ -1574,7 +1577,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1667,7 +1670,7 @@ checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2021,7 +2024,7 @@ dependencies = [
 name = "idstore-export"
 version = "0.1.1"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "clap 3.2.25",
  "merk",
  "serde",
@@ -2060,18 +2063,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console",
- "lazy_static",
- "number_prefix",
- "regex",
 ]
 
 [[package]]
@@ -2199,7 +2190,7 @@ version = "0.1.1"
 dependencies = [
  "clap 3.2.25",
  "hex",
- "indicatif 0.17.3",
+ "indicatif",
  "log-panics",
  "many-client",
  "many-error",
@@ -2236,7 +2227,7 @@ dependencies = [
  "crc-any",
  "hex",
  "humantime",
- "indicatif 0.16.2",
+ "indicatif",
  "lazy_static",
  "many-cli-helpers",
  "many-client",
@@ -2371,7 +2362,7 @@ checksum = "c880e0101fc5844ae1c2f3b5b50aba1fb1939e308149dc2dde33b80a0816df18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2416,7 +2407,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "atty",
- "base64 0.21.0",
+ "base64 0.21.2",
  "cbor-diag",
  "clap 3.2.25",
  "coset",
@@ -2447,7 +2438,7 @@ name = "many-abci"
 version = "0.1.1"
 dependencies = [
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "ciborium",
  "clap 3.2.25",
  "coset",
@@ -2503,7 +2494,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base32",
- "base64 0.21.0",
+ "base64 0.21.2",
  "coset",
  "crc-any",
  "derive_builder",
@@ -2542,7 +2533,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2625,7 +2616,7 @@ name = "many-identity-webauthn"
 version = "0.1.1"
 dependencies = [
  "authenticator-ctap2-2021",
- "base64 0.21.0",
+ "base64 0.21.2",
  "base64urlsafedata",
  "coset",
  "hex",
@@ -2688,7 +2679,7 @@ version = "0.1.1"
 dependencies = [
  "async-channel",
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bip39-dict",
  "clap 3.2.25",
  "const_format",
@@ -2736,7 +2727,7 @@ name = "many-ledger-test-macros"
 version = "0.1.1"
 dependencies = [
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2773,7 +2764,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2811,7 +2802,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml 0.7.3",
+ "toml 0.7.4",
 ]
 
 [[package]]
@@ -2846,7 +2837,7 @@ name = "many-protocol"
 version = "0.1.1"
 dependencies = [
  "async-channel",
- "base64 0.21.0",
+ "base64 0.21.2",
  "coset",
  "derive_builder",
  "hex",
@@ -2872,7 +2863,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "base32",
- "base64 0.21.0",
+ "base64 0.21.2",
  "coset",
  "crc-any",
  "derive_builder",
@@ -2909,7 +2900,7 @@ dependencies = [
 name = "many-types"
 version = "0.1.1"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "cbor-diag",
  "coset",
  "derive_more",
@@ -3191,23 +3182,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3269,7 +3260,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3415,7 +3406,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "serde",
 ]
 
@@ -3464,7 +3455,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3638,25 +3629,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error 2.0.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
@@ -3705,16 +3695,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -3819,13 +3803,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick 1.0.1",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -3836,17 +3820,17 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4031,7 +4015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -4151,9 +4135,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -4189,13 +4173,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -4217,23 +4201,23 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_test"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2931818f5d80d6bbe619cc30edd53b822fac51e1f6833cd4659072d701721b"
+checksum = "100168a8017b89fd4bcbeb8d857d95a8cfcbde829a7147c09cc82d3ab8d8cb41"
 dependencies = [
  "serde",
 ]
@@ -4247,7 +4231,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -4494,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "45b6ddbb36c5b969c182aec3c4a0bce7df3fbad4b77114706a49aacc80567388"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4550,9 +4534,9 @@ dependencies = [
 
 [[package]]
 name = "syslog-tracing"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf9ff1f9f8e5ba220a58bbccb0375f4cabd785f96a8683b31389cefd91be747"
+checksum = "2f890b68f60eb7e87373b3b8f1f412d2a7d90460cd18294acbc0e90ba496193e"
 dependencies = [
  "libc",
  "tracing-core",
@@ -4737,7 +4721,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -4806,9 +4790,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4831,7 +4815,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -4880,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -4892,18 +4876,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "serde",
@@ -4938,7 +4922,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -5123,9 +5107,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.1.3"
+version = "8.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e03272e388fb78fc79481a493424f78d77be1d55f21bcd314b5a6716e195afe"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
 dependencies = [
  "anyhow",
  "git2",
@@ -5594,5 +5578,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -137,7 +137,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror",
@@ -334,7 +334,7 @@ dependencies = [
  "libudev",
  "log",
  "memoffset",
- "nom 7.1.3",
+ "nom",
  "openssl",
  "openssl-sys",
  "rand 0.8.5",
@@ -537,9 +537,12 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bstr"
@@ -597,15 +600,15 @@ dependencies = [
 
 [[package]]
 name = "cbor-diag"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2644c5bb01d8328b218301180b84ccc6f7fce031d50e30917b07ae762a185b7b"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
 dependencies = [
  "bs58",
  "chrono",
  "data-encoding",
  "half 2.2.1",
- "nom 5.1.3",
+ "nom",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -629,7 +632,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1068,7 +1071,7 @@ checksum = "d40d2fdf5e1bb4ae7e6b25c97bf9b9d249a02243fc0fbd91075592b5f00a3bc1"
 dependencies = [
  "derive_more",
  "either",
- "nom 7.1.3",
+ "nom",
  "nom_locate",
  "regex",
  "regex-syntax 0.6.29",
@@ -1153,7 +1156,7 @@ checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1221,7 +1224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9313f104b590510b46fc01c0a324fc76505c13871454d3c48490468d04c8d395"
 dependencies = [
  "libc",
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -3071,16 +3074,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -3097,7 +3090,7 @@ checksum = "b1e299bf5ea7b212e811e71174c5d1a5d065c4c0ad0c8691ecb1f97e3e66025e"
 dependencies = [
  "bytecount",
  "memchr",
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -3960,7 +3953,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -5255,7 +5248,7 @@ dependencies = [
  "authenticator-ctap2-2021",
  "base64urlsafedata",
  "hidapi",
- "nom 7.1.3",
+ "nom",
  "openssl",
  "rpassword 5.0.1",
  "serde",
@@ -5291,7 +5284,7 @@ dependencies = [
  "base64urlsafedata",
  "compact_jwt",
  "der-parser",
- "nom 7.1.3",
+ "nom",
  "openssl",
  "rand 0.8.5",
  "serde",
@@ -5554,7 +5547,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom 7.1.3",
+ "nom",
  "oid-registry",
  "rusticata-macros",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "arrayref"
@@ -121,12 +121,11 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "asn1"
-version = "0.13.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2affba5e62ee09eeba078f01a00c4aed45ac4287e091298eccbb0d4802efbdc5"
+checksum = "28c19b9324de5b815b6487e0f8098312791b09de0dbf3d5c2db1fe2d95bab973"
 dependencies = [
  "asn1_derive",
- "chrono",
 ]
 
 [[package]]
@@ -170,13 +169,13 @@ dependencies = [
 
 [[package]]
 name = "asn1_derive"
-version = "0.13.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfab79c195875e5aef2bd20b4c8ed8d43ef9610bcffefbbcf66f88f555cc78af"
+checksum = "a045c3ccad89f244a86bd1e6cf1a7bf645296e7692698b056399b6efd4639407"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -283,7 +282,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -300,7 +299,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -395,9 +394,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -411,7 +410,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18b3d30abb74120a9d5267463b9e0045fdccc4dd152e7249d966612dc1721384"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "serde",
  "serde_json",
 ]
@@ -663,8 +662,9 @@ checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -673,13 +673,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
-source = "git+https://github.com/enarx/ciborium?rev=2ca375e6b33d1ade5a5798792278b35a807b748e#2ca375e6b33d1ade5a5798792278b35a807b748e"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half 1.8.2",
@@ -698,13 +700,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 3.2.18",
+ "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
@@ -740,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -760,7 +762,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1008,7 +1010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1274,15 +1276,16 @@ checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.6"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der",
  "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
  "signature 2.1.0",
+ "spki",
 ]
 
 [[package]]
@@ -1574,7 +1577,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1667,7 +1670,7 @@ checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1678,9 +1681,9 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
 dependencies = [
  "bitflags",
  "libc",
@@ -1893,7 +1896,7 @@ dependencies = [
 name = "http_proxy"
 version = "0.1.1"
 dependencies = [
- "clap 3.2.23",
+ "clap 3.2.25",
  "hex",
  "log-panics",
  "many-client",
@@ -2021,8 +2024,8 @@ dependencies = [
 name = "idstore-export"
 version = "0.1.1"
 dependencies = [
- "base64 0.21.0",
- "clap 3.2.23",
+ "base64 0.21.2",
+ "clap 3.2.25",
  "merk",
  "serde",
  "serde_derive",
@@ -2060,18 +2063,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console",
- "lazy_static",
- "number_prefix",
- "regex",
 ]
 
 [[package]]
@@ -2186,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -2197,9 +2188,9 @@ dependencies = [
 name = "kvstore"
 version = "0.1.1"
 dependencies = [
- "clap 3.2.23",
+ "clap 3.2.25",
  "hex",
- "indicatif 0.17.3",
+ "indicatif",
  "log-panics",
  "many-client",
  "many-error",
@@ -2232,11 +2223,11 @@ name = "ledger"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "clap 3.2.23",
+ "clap 3.2.25",
  "crc-any",
  "hex",
  "humantime",
- "indicatif 0.16.2",
+ "indicatif",
  "lazy_static",
  "many-cli-helpers",
  "many-client",
@@ -2260,7 +2251,7 @@ dependencies = [
 name = "ledger-db"
 version = "0.1.1"
 dependencies = [
- "clap 3.2.23",
+ "clap 3.2.25",
  "hex",
  "many-modules",
  "many-types",
@@ -2276,9 +2267,9 @@ checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.15.1+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
 dependencies = [
  "cc",
  "libc",
@@ -2371,7 +2362,7 @@ checksum = "c880e0101fc5844ae1c2f3b5b50aba1fb1939e308149dc2dde33b80a0816df18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2416,9 +2407,9 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "atty",
- "base64 0.21.0",
+ "base64 0.21.2",
  "cbor-diag",
- "clap 3.2.23",
+ "clap 3.2.25",
  "coset",
  "hex",
  "many-cli-helpers",
@@ -2447,9 +2438,9 @@ name = "many-abci"
 version = "0.1.1"
 dependencies = [
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "ciborium",
- "clap 3.2.23",
+ "clap 3.2.25",
  "coset",
  "hex",
  "itertools",
@@ -2487,7 +2478,7 @@ name = "many-cli-helpers"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "clap 3.2.23",
+ "clap 3.2.25",
  "log-panics",
  "many-error",
  "minicbor",
@@ -2503,7 +2494,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base32",
- "base64 0.21.0",
+ "base64 0.21.2",
  "coset",
  "crc-any",
  "derive_builder",
@@ -2542,7 +2533,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2625,7 +2616,7 @@ name = "many-identity-webauthn"
 version = "0.1.1"
 dependencies = [
  "authenticator-ctap2-2021",
- "base64 0.21.0",
+ "base64 0.21.2",
  "base64urlsafedata",
  "coset",
  "hex",
@@ -2655,7 +2646,7 @@ version = "0.1.1"
 dependencies = [
  "async-channel",
  "async-trait",
- "clap 3.2.23",
+ "clap 3.2.25",
  "coset",
  "hex",
  "json5",
@@ -2688,9 +2679,9 @@ version = "0.1.1"
 dependencies = [
  "async-channel",
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bip39-dict",
- "clap 3.2.23",
+ "clap 3.2.25",
  "const_format",
  "coset",
  "cucumber",
@@ -2736,7 +2727,7 @@ name = "many-ledger-test-macros"
 version = "0.1.1"
 dependencies = [
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2773,7 +2764,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2811,7 +2802,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml 0.7.3",
+ "toml 0.7.4",
 ]
 
 [[package]]
@@ -2846,7 +2837,7 @@ name = "many-protocol"
 version = "0.1.1"
 dependencies = [
  "async-channel",
- "base64 0.21.0",
+ "base64 0.21.2",
  "coset",
  "derive_builder",
  "hex",
@@ -2872,7 +2863,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "base32",
- "base64 0.21.0",
+ "base64 0.21.2",
  "coset",
  "crc-any",
  "derive_builder",
@@ -2909,7 +2900,7 @@ dependencies = [
 name = "many-types"
 version = "0.1.1"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "cbor-diag",
  "coset",
  "derive_more",
@@ -3191,23 +3182,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3269,7 +3260,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3415,7 +3406,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "serde",
 ]
 
@@ -3464,7 +3455,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3629,25 +3620,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error 2.0.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
@@ -3696,16 +3686,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -3810,13 +3794,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick 1.0.1",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -3827,17 +3811,17 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4022,7 +4006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -4142,9 +4126,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -4180,13 +4164,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -4208,23 +4192,23 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_test"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c95a500e3923258f7fc3a16bf29934e403aef5ca1096e184d85e3b1926675e8"
+checksum = "100168a8017b89fd4bcbeb8d857d95a8cfcbde829a7147c09cc82d3ab8d8cb41"
 dependencies = [
  "serde",
 ]
@@ -4238,7 +4222,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -4290,9 +4274,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -4415,9 +4399,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
  "der",
@@ -4485,9 +4469,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "45b6ddbb36c5b969c182aec3c4a0bce7df3fbad4b77114706a49aacc80567388"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4541,9 +4525,9 @@ dependencies = [
 
 [[package]]
 name = "syslog-tracing"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf9ff1f9f8e5ba220a58bbccb0375f4cabd785f96a8683b31389cefd91be747"
+checksum = "2f890b68f60eb7e87373b3b8f1f412d2a7d90460cd18294acbc0e90ba496193e"
 dependencies = [
  "libc",
  "tracing-core",
@@ -4728,7 +4712,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -4797,9 +4781,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4811,18 +4795,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -4871,9 +4855,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -4883,18 +4867,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "serde",
@@ -4955,9 +4939,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -5114,9 +5098,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.1.1"
+version = "8.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b86a8af1dedf089b1c78338678e4c7492b6045649042d94faf19690499d236"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
 dependencies = [
  "anyhow",
  "git2",
@@ -5534,9 +5518,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]
@@ -5585,5 +5569,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.17",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror",
@@ -334,7 +334,7 @@ dependencies = [
  "libudev",
  "log",
  "memoffset",
- "nom 7.1.3",
+ "nom",
  "openssl",
  "openssl-sys",
  "rand 0.8.5",
@@ -537,9 +537,12 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bstr"
@@ -597,15 +600,15 @@ dependencies = [
 
 [[package]]
 name = "cbor-diag"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2644c5bb01d8328b218301180b84ccc6f7fce031d50e30917b07ae762a185b7b"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
 dependencies = [
  "bs58",
  "chrono",
  "data-encoding",
  "half 2.2.1",
- "nom 5.1.2",
+ "nom",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -629,7 +632,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1068,7 +1071,7 @@ checksum = "d40d2fdf5e1bb4ae7e6b25c97bf9b9d249a02243fc0fbd91075592b5f00a3bc1"
 dependencies = [
  "derive_more",
  "either",
- "nom 7.1.3",
+ "nom",
  "nom_locate",
  "regex",
  "regex-syntax 0.6.29",
@@ -1153,7 +1156,7 @@ checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1221,7 +1224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9313f104b590510b46fc01c0a324fc76505c13871454d3c48490468d04c8d395"
 dependencies = [
  "libc",
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -3071,16 +3074,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -3097,7 +3090,7 @@ checksum = "b1e299bf5ea7b212e811e71174c5d1a5d065c4c0ad0c8691ecb1f97e3e66025e"
 dependencies = [
  "bytecount",
  "memchr",
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -3951,7 +3944,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -5246,7 +5239,7 @@ dependencies = [
  "authenticator-ctap2-2021",
  "base64urlsafedata",
  "hidapi",
- "nom 7.1.3",
+ "nom",
  "openssl",
  "rpassword 5.0.1",
  "serde",
@@ -5282,7 +5275,7 @@ dependencies = [
  "base64urlsafedata",
  "compact_jwt",
  "der-parser",
- "nom 7.1.3",
+ "nom",
  "openssl",
  "rand 0.8.5",
  "serde",
@@ -5545,7 +5538,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom 7.1.3",
+ "nom",
  "oid-registry",
  "rusticata-macros",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,3 @@ incremental = false
 
 [profile.dev]
 incremental = false
-
-[patch.crates-io]
-ciborium = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }
-ciborium-io = { git = "https://github.com/enarx/ciborium", rev = "2ca375e6b33d1ade5a5798792278b35a807b748e" }

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6f2fc5fd39682d2b2176e2f16cd98542b3d25b8d3d2584d395407dd502b93ba9",
+  "checksum": "74fa8a0dba288d8ddf409584c522cef460ddef75cf6a3a50c6e7914730312c6d",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -646,13 +646,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "asn1 0.13.0": {
+    "asn1 0.15.2": {
       "name": "asn1",
-      "version": "0.13.0",
+      "version": "0.15.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/asn1/0.13.0/download",
-          "sha256": "2affba5e62ee09eeba078f01a00c4aed45ac4287e091298eccbb0d4802efbdc5"
+          "url": "https://crates.io/api/v1/crates/asn1/0.15.2/download",
+          "sha256": "28c19b9324de5b815b6487e0f8098312791b09de0dbf3d5c2db1fe2d95bab973"
         }
       },
       "targets": [
@@ -673,32 +673,22 @@
         ],
         "crate_features": {
           "common": [
-            "const-generics",
             "default",
             "std"
           ],
           "selects": {}
         },
-        "deps": {
-          "common": [
-            {
-              "id": "chrono 0.4.24",
-              "target": "chrono"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
+        "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "asn1_derive 0.13.0",
+              "id": "asn1_derive 0.15.2",
               "target": "asn1_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.13.0"
+        "version": "0.15.2"
       },
       "license": "BSD-3-Clause"
     },
@@ -811,11 +801,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -862,11 +852,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -881,13 +871,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "asn1_derive 0.13.0": {
+    "asn1_derive 0.15.2": {
       "name": "asn1_derive",
-      "version": "0.13.0",
+      "version": "0.15.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/asn1_derive/0.13.0/download",
-          "sha256": "bfab79c195875e5aef2bd20b4c8ed8d43ef9610bcffefbbcf66f88f555cc78af"
+          "url": "https://crates.io/api/v1/crates/asn1_derive/0.15.2/download",
+          "sha256": "a045c3ccad89f244a86bd1e6cf1a7bf645296e7692698b056399b6efd4639407"
         }
       },
       "targets": [
@@ -909,22 +899,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.13.0"
+        "edition": "2021",
+        "version": "0.15.2"
       },
       "license": "BSD-3-Clause"
     },
@@ -1458,15 +1448,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -1555,15 +1545,15 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -1751,7 +1741,7 @@
               "target": "runloop"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -2091,13 +2081,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "base64 0.21.0": {
+    "base64 0.21.2": {
       "name": "base64",
-      "version": "0.21.0",
+      "version": "0.21.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/base64/0.21.0/download",
-          "sha256": "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+          "url": "https://crates.io/api/v1/crates/base64/0.21.2/download",
+          "sha256": "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
         }
       },
       "targets": [
@@ -2124,7 +2114,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.21.0"
+        "version": "0.21.2"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2192,11 +2182,11 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -2291,15 +2281,15 @@
               "target": "peeking_take_while"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
@@ -2402,15 +2392,15 @@
               "target": "peeking_take_while"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
@@ -3088,7 +3078,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -3473,16 +3463,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ciborium 0.2.0": {
+    "ciborium 0.2.1": {
       "name": "ciborium",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/enarx/ciborium",
-          "commitish": {
-            "Rev": "2ca375e6b33d1ade5a5798792278b35a807b748e"
-          },
-          "strip_prefix": "ciborium"
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ciborium/0.2.1/download",
+          "sha256": "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
         }
       },
       "targets": [
@@ -3511,35 +3498,32 @@
         "deps": {
           "common": [
             {
-              "id": "ciborium-io 0.2.0",
+              "id": "ciborium-io 0.2.1",
               "target": "ciborium_io"
             },
             {
-              "id": "ciborium-ll 0.2.0",
+              "id": "ciborium-ll 0.2.1",
               "target": "ciborium_ll"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.0"
+        "version": "0.2.1"
       },
       "license": "Apache-2.0"
     },
-    "ciborium-io 0.2.0": {
+    "ciborium-io 0.2.1": {
       "name": "ciborium-io",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/enarx/ciborium",
-          "commitish": {
-            "Rev": "2ca375e6b33d1ade5a5798792278b35a807b748e"
-          },
-          "strip_prefix": "ciborium-io"
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ciborium-io/0.2.1/download",
+          "sha256": "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
         }
       },
       "targets": [
@@ -3566,20 +3550,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.0"
+        "version": "0.2.1"
       },
       "license": "Apache-2.0"
     },
-    "ciborium-ll 0.2.0": {
+    "ciborium-ll 0.2.1": {
       "name": "ciborium-ll",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/enarx/ciborium",
-          "commitish": {
-            "Rev": "2ca375e6b33d1ade5a5798792278b35a807b748e"
-          },
-          "strip_prefix": "ciborium-ll"
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ciborium-ll/0.2.1/download",
+          "sha256": "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
         }
       },
       "targets": [
@@ -3601,7 +3582,7 @@
         "deps": {
           "common": [
             {
-              "id": "ciborium-io 0.2.0",
+              "id": "ciborium-io 0.2.1",
               "target": "ciborium_io"
             },
             {
@@ -3612,7 +3593,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.0"
+        "version": "0.2.1"
       },
       "license": "Apache-2.0"
     },
@@ -3976,11 +3957,11 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -4033,15 +4014,15 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -4252,7 +4233,7 @@
               "target": "openssl"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -4500,11 +4481,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -4686,11 +4667,11 @@
         "deps": {
           "common": [
             {
-              "id": "ciborium 0.2.0",
+              "id": "ciborium 0.2.1",
               "target": "ciborium"
             },
             {
-              "id": "ciborium-io 0.2.0",
+              "id": "ciborium-io 0.2.1",
               "target": "ciborium_io"
             }
           ],
@@ -5322,11 +5303,11 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -5434,11 +5415,11 @@
               "target": "once_cell"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -5518,15 +5499,15 @@
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
@@ -5594,7 +5575,7 @@
               "target": "nom_locate"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
@@ -5779,11 +5760,11 @@
               "target": "ident_case"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -5834,7 +5815,7 @@
               "target": "darling_core"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -6075,11 +6056,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -6172,11 +6153,11 @@
               "target": "darling"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -6297,11 +6278,11 @@
               "target": "convert_case"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -6535,15 +6516,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -6621,13 +6602,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ecdsa 0.16.6": {
+    "ecdsa 0.16.7": {
       "name": "ecdsa",
-      "version": "0.16.6",
+      "version": "0.16.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ecdsa/0.16.6/download",
-          "sha256": "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+          "url": "https://crates.io/api/v1/crates/ecdsa/0.16.7/download",
+          "sha256": "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
         }
       },
       "targets": [
@@ -6658,6 +6639,7 @@
             "pkcs8",
             "rfc6979",
             "signing",
+            "spki",
             "std",
             "verifying"
           ],
@@ -6684,12 +6666,16 @@
             {
               "id": "signature 2.1.0",
               "target": "signature"
+            },
+            {
+              "id": "spki 0.7.2",
+              "target": "spki"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.16.6"
+        "version": "0.16.7"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -6769,11 +6755,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -6936,7 +6922,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde",
               "alias": "serde_crate"
             },
@@ -8242,15 +8228,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -8786,11 +8772,11 @@
               "target": "heck"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -8835,15 +8821,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -9027,7 +9013,7 @@
               "target": "log"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             }
           ],
@@ -9198,7 +9184,7 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -9662,7 +9648,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -9931,7 +9917,7 @@
               "target": "new_mime_guess"
             },
             {
-              "id": "syslog-tracing 0.1.0",
+              "id": "syslog-tracing 0.2.0",
               "target": "syslog_tracing"
             },
             {
@@ -9939,7 +9925,7 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -10167,7 +10153,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -10257,7 +10243,7 @@
               "target": "rustls_native_certs"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -10343,7 +10329,7 @@
               "target": "rustls_native_certs"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -10406,7 +10392,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -10507,7 +10493,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -10519,7 +10505,7 @@
               "target": "merk"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -10533,7 +10519,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.162",
+              "id": "serde_derive 1.0.163",
               "target": "serde_derive"
             }
           ],
@@ -10587,7 +10573,7 @@
               "target": "memchr"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
@@ -10724,63 +10710,6 @@
         }
       },
       "license": "Apache-2.0 OR MIT"
-    },
-    "indicatif 0.16.2": {
-      "name": "indicatif",
-      "version": "0.16.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/indicatif/0.16.2/download",
-          "sha256": "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "indicatif",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "indicatif",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "console 0.15.5",
-              "target": "console"
-            },
-            {
-              "id": "lazy_static 1.4.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "number_prefix 0.4.0",
-              "target": "number_prefix"
-            },
-            {
-              "id": "regex 1.8.1",
-              "target": "regex"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.16.2"
-      },
-      "license": "MIT"
     },
     "indicatif 0.17.3": {
       "name": "indicatif",
@@ -11317,7 +11246,7 @@
               "target": "pest"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -11411,11 +11340,11 @@
               "target": "minicbor"
             },
             {
-              "id": "syslog-tracing 0.1.0",
+              "id": "syslog-tracing 0.2.0",
               "target": "syslog_tracing"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -11527,7 +11456,7 @@
               "target": "humantime"
             },
             {
-              "id": "indicatif 0.16.2",
+              "id": "indicatif 0.17.3",
               "target": "indicatif"
             },
             {
@@ -11547,7 +11476,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
@@ -11559,7 +11488,7 @@
               "target": "serde_json"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -12324,15 +12253,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -12597,7 +12526,7 @@
               "target": "atty"
             },
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -12629,7 +12558,7 @@
               "target": "rpassword"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -12693,11 +12622,11 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
-              "id": "ciborium 0.2.0",
+              "id": "ciborium 0.2.1",
               "target": "ciborium"
             },
             {
@@ -12741,7 +12670,7 @@
               "target": "num_integer"
             },
             {
-              "id": "reqwest 0.11.17",
+              "id": "reqwest 0.11.18",
               "target": "reqwest"
             },
             {
@@ -12773,7 +12702,7 @@
               "target": "tendermint_rpc"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -12802,7 +12731,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 8.1.3",
+              "id": "vergen 8.2.1",
               "target": "vergen"
             }
           ],
@@ -12850,7 +12779,7 @@
               "target": "minicbor"
             },
             {
-              "id": "syslog-tracing 0.1.0",
+              "id": "syslog-tracing 0.2.0",
               "target": "syslog_tracing"
             },
             {
@@ -12906,7 +12835,7 @@
               "target": "base32"
             },
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -12922,7 +12851,7 @@
               "target": "derive_builder"
             },
             {
-              "id": "ecdsa 0.16.6",
+              "id": "ecdsa 0.16.7",
               "target": "ecdsa"
             },
             {
@@ -12962,15 +12891,15 @@
               "target": "rand"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
-              "id": "reqwest 0.11.17",
+              "id": "reqwest 0.11.18",
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -12986,7 +12915,7 @@
               "target": "tiny_http"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -13037,15 +12966,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -13094,7 +13023,7 @@
               "target": "num_traits"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             }
           ],
@@ -13172,7 +13101,7 @@
               "target": "once_cell"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -13193,11 +13122,11 @@
         "deps_dev": {
           "common": [
             {
-              "id": "proptest 1.1.0",
+              "id": "proptest 1.2.0",
               "target": "proptest"
             },
             {
-              "id": "serde_test 1.0.162",
+              "id": "serde_test 1.0.163",
               "target": "serde_test"
             }
           ],
@@ -13284,7 +13213,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -13305,11 +13234,11 @@
         "deps_dev": {
           "common": [
             {
-              "id": "proptest 1.1.0",
+              "id": "proptest 1.2.0",
               "target": "proptest"
             },
             {
-              "id": "serde_test 1.0.162",
+              "id": "serde_test 1.0.163",
               "target": "serde_test"
             }
           ],
@@ -13343,7 +13272,7 @@
         "deps": {
           "common": [
             {
-              "id": "asn1 0.13.0",
+              "id": "asn1 0.15.2",
               "target": "asn1"
             },
             {
@@ -13416,7 +13345,7 @@
               "target": "authenticator_ctap2_2021"
             },
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -13444,7 +13373,7 @@
               "target": "rpassword"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -13560,7 +13489,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -13576,7 +13505,7 @@
               "target": "strum"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -13622,7 +13551,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 8.1.3",
+              "id": "vergen 8.2.1",
               "target": "vergen"
             }
           ],
@@ -13675,7 +13604,7 @@
               "target": "async_channel"
             },
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -13739,7 +13668,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -13759,7 +13688,7 @@
               "target": "strum"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -13784,7 +13713,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proptest 1.1.0",
+              "id": "proptest 1.2.0",
               "target": "proptest"
             },
             {
@@ -13813,7 +13742,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 8.1.3",
+              "id": "vergen 8.2.1",
               "target": "vergen"
             }
           ],
@@ -13845,11 +13774,11 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -13911,7 +13840,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proptest 1.1.0",
+              "id": "proptest 1.2.0",
               "target": "proptest"
             },
             {
@@ -13961,15 +13890,15 @@
               "target": "inflections"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -13977,7 +13906,7 @@
               "target": "serde_tokenstream"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -14015,7 +13944,7 @@
               "target": "minicbor"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -14078,15 +14007,15 @@
               "target": "coset"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
-              "id": "toml 0.7.3",
+              "id": "toml 0.7.4",
               "target": "toml"
             }
           ],
@@ -14095,7 +14024,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "ciborium 0.2.0",
+              "id": "ciborium 0.2.1",
               "target": "ciborium"
             },
             {
@@ -14111,7 +14040,7 @@
               "target": "serde_json"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             }
           ],
@@ -14184,7 +14113,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "num_enum 0.5.11",
+              "id": "num_enum 0.6.1",
               "target": "num_enum"
             },
             {
@@ -14209,7 +14138,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proptest 1.1.0",
+              "id": "proptest 1.2.0",
               "target": "proptest"
             },
             {
@@ -14264,7 +14193,7 @@
               "target": "async_channel"
             },
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -14292,7 +14221,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -14313,7 +14242,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proptest 1.1.0",
+              "id": "proptest 1.2.0",
               "target": "proptest"
             }
           ],
@@ -14371,7 +14300,7 @@
               "target": "base32"
             },
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -14411,11 +14340,11 @@
               "target": "once_cell"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -14444,7 +14373,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "proptest 1.1.0",
+              "id": "proptest 1.2.0",
               "target": "proptest"
             },
             {
@@ -14510,7 +14439,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -14538,11 +14467,11 @@
               "target": "num_traits"
             },
             {
-              "id": "proptest 1.1.0",
+              "id": "proptest 1.2.0",
               "target": "proptest"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -14555,7 +14484,7 @@
               "target": "cbor_diag"
             },
             {
-              "id": "serde_test 1.0.162",
+              "id": "serde_test 1.0.163",
               "target": "serde_test"
             }
           ],
@@ -15019,11 +14948,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -15284,11 +15213,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -15840,11 +15769,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -16135,13 +16064,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "num_enum 0.5.11": {
+    "num_enum 0.6.1": {
       "name": "num_enum",
-      "version": "0.5.11",
+      "version": "0.6.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num_enum/0.5.11/download",
-          "sha256": "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+          "url": "https://crates.io/api/v1/crates/num_enum/0.6.1/download",
+          "sha256": "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
         }
       },
       "targets": [
@@ -16167,27 +16096,27 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
+        "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "num_enum_derive 0.5.11",
+              "id": "num_enum_derive 0.6.1",
               "target": "num_enum_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.5.11"
+        "version": "0.6.1"
       },
       "license": "BSD-3-Clause OR MIT OR Apache-2.0"
     },
-    "num_enum_derive 0.5.11": {
+    "num_enum_derive 0.6.1": {
       "name": "num_enum_derive",
-      "version": "0.5.11",
+      "version": "0.6.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num_enum_derive/0.5.11/download",
-          "sha256": "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+          "url": "https://crates.io/api/v1/crates/num_enum_derive/0.6.1/download",
+          "sha256": "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
         }
       },
       "targets": [
@@ -16220,22 +16149,22 @@
               "target": "proc_macro_crate"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.109",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.5.11"
+        "edition": "2021",
+        "version": "0.6.1"
       },
       "license": "BSD-3-Clause OR MIT OR Apache-2.0"
     },
@@ -16600,15 +16529,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -16837,7 +16766,7 @@
         "deps": {
           "common": [
             {
-              "id": "ecdsa 0.16.6",
+              "id": "ecdsa 0.16.7",
               "target": "ecdsa",
               "alias": "ecdsa_core"
             },
@@ -17231,11 +17160,11 @@
               "target": "peg_runtime"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             }
           ],
@@ -17278,11 +17207,11 @@
               "target": "peg_runtime"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             }
           ],
@@ -17578,15 +17507,15 @@
               "target": "pest_meta"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -17707,11 +17636,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -18188,7 +18117,7 @@
               "target": "predicates_core"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             }
           ],
@@ -18343,7 +18272,7 @@
               "target": "once_cell"
             },
             {
-              "id": "toml_edit 0.19.8",
+              "id": "toml_edit 0.19.10",
               "target": "toml_edit"
             }
           ],
@@ -18403,11 +18332,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -18486,11 +18415,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             }
           ],
@@ -18515,13 +18444,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.56": {
+    "proc-macro2 1.0.59": {
       "name": "proc-macro2",
-      "version": "1.0.56",
+      "version": "1.0.59",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.56/download",
-          "sha256": "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.59/download",
+          "sha256": "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
         }
       },
       "targets": [
@@ -18559,7 +18488,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "build_script_build"
             },
             {
@@ -18570,7 +18499,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.56"
+        "version": "1.0.59"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -18579,13 +18508,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proptest 1.1.0": {
+    "proptest 1.2.0": {
       "name": "proptest",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proptest/1.1.0/download",
-          "sha256": "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+          "url": "https://crates.io/api/v1/crates/proptest/1.2.0/download",
+          "sha256": "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
         }
       },
       "targets": [
@@ -18611,7 +18540,6 @@
             "default",
             "fork",
             "lazy_static",
-            "quick-error",
             "regex-syntax",
             "rusty-fork",
             "std",
@@ -18641,10 +18569,6 @@
             {
               "id": "num-traits 0.2.15",
               "target": "num_traits"
-            },
-            {
-              "id": "quick-error 2.0.1",
-              "target": "quick_error"
             },
             {
               "id": "rand 0.8.5",
@@ -18678,7 +18602,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.1.0"
+        "version": "1.2.0"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -18772,11 +18696,11 @@
               "target": "itertools"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -18860,43 +18784,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "quick-error 2.0.1": {
-      "name": "quick-error",
-      "version": "2.0.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/quick-error/2.0.1/download",
-          "sha256": "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "quick_error",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "quick_error",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "2.0.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "quote 1.0.27": {
+    "quote 1.0.28": {
       "name": "quote",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.27/download",
-          "sha256": "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.28/download",
+          "sha256": "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
         }
       },
       "targets": [
@@ -18934,18 +18828,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.27"
+        "version": "1.0.28"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -19439,13 +19333,13 @@
       },
       "license": "MIT"
     },
-    "regex 1.8.1": {
+    "regex 1.8.3": {
       "name": "regex",
-      "version": "1.8.1",
+      "version": "1.8.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex/1.8.1/download",
-          "sha256": "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+          "url": "https://crates.io/api/v1/crates/regex/1.8.3/download",
+          "sha256": "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
         }
       },
       "targets": [
@@ -19497,14 +19391,14 @@
               "target": "memchr"
             },
             {
-              "id": "regex-syntax 0.7.1",
+              "id": "regex-syntax 0.7.2",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.8.1"
+        "version": "1.8.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -19552,13 +19446,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "regex-syntax 0.7.1": {
+    "regex-syntax 0.7.2": {
       "name": "regex-syntax",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex-syntax/0.7.1/download",
-          "sha256": "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+          "url": "https://crates.io/api/v1/crates/regex-syntax/0.7.2/download",
+          "sha256": "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
         }
       },
       "targets": [
@@ -19593,17 +19487,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.1"
+        "version": "0.7.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "reqwest 0.11.17": {
+    "reqwest 0.11.18": {
       "name": "reqwest",
-      "version": "0.11.17",
+      "version": "0.11.18",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/reqwest/0.11.17/download",
-          "sha256": "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+          "url": "https://crates.io/api/v1/crates/reqwest/0.11.18/download",
+          "sha256": "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
         }
       },
       "targets": [
@@ -19637,7 +19531,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.0",
+              "id": "base64 0.21.2",
               "target": "base64"
             },
             {
@@ -19657,7 +19551,7 @@
               "target": "http"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -19725,7 +19619,7 @@
                 "target": "pin_project_lite"
               },
               {
-                "id": "tokio 1.28.0",
+                "id": "tokio 1.28.1",
                 "target": "tokio"
               },
               {
@@ -19760,7 +19654,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.11.17"
+        "version": "0.11.18"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -20995,11 +20889,11 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -21046,11 +20940,11 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -21340,13 +21234,13 @@
       },
       "license": "MIT"
     },
-    "serde 1.0.162": {
+    "serde 1.0.163": {
       "name": "serde",
-      "version": "1.0.162",
+      "version": "1.0.163",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.162/download",
-          "sha256": "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.163/download",
+          "sha256": "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
         }
       },
       "targets": [
@@ -21387,7 +21281,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "build_script_build"
             }
           ],
@@ -21397,13 +21291,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.162",
+              "id": "serde_derive 1.0.163",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.162"
+        "version": "1.0.163"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -21448,7 +21342,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -21498,7 +21392,7 @@
               "target": "half"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -21548,7 +21442,7 @@
               "target": "half"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -21559,13 +21453,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "serde_derive 1.0.162": {
+    "serde_derive 1.0.163": {
       "name": "serde_derive",
-      "version": "1.0.162",
+      "version": "1.0.163",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.162/download",
-          "sha256": "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.163/download",
+          "sha256": "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
         }
       },
       "targets": [
@@ -21573,15 +21467,6 @@
           "ProcMacro": {
             "crate_name": "serde_derive",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": [
               "**/*.rs"
             ]
@@ -21602,31 +21487,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "serde_derive 1.0.162",
-              "target": "build_script_build"
-            },
-            {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.162"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
+        "version": "1.0.163"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -21683,7 +21559,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -21731,15 +21607,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -21750,13 +21626,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_spanned 0.6.1": {
+    "serde_spanned 0.6.2": {
       "name": "serde_spanned",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_spanned/0.6.1/download",
-          "sha256": "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+          "url": "https://crates.io/api/v1/crates/serde_spanned/0.6.2/download",
+          "sha256": "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
         }
       },
       "targets": [
@@ -21784,24 +21660,24 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.1"
+        "version": "0.6.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_test 1.0.162": {
+    "serde_test 1.0.163": {
       "name": "serde_test",
-      "version": "1.0.162",
+      "version": "1.0.163",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_test/1.0.162/download",
-          "sha256": "2b2931818f5d80d6bbe619cc30edd53b822fac51e1f6833cd4659072d701721b"
+          "url": "https://crates.io/api/v1/crates/serde_test/1.0.163/download",
+          "sha256": "100168a8017b89fd4bcbeb8d857d95a8cfcbde829a7147c09cc82d3ab8d8cb41"
         }
       },
       "targets": [
@@ -21832,18 +21708,18 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
-              "id": "serde_test 1.0.162",
+              "id": "serde_test 1.0.163",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.162"
+        "version": "1.0.163"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -21880,19 +21756,19 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -21943,7 +21819,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -22581,11 +22457,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -22971,11 +22847,11 @@
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -23138,11 +23014,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -23166,13 +23042,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "syn 2.0.15": {
+    "syn 2.0.17": {
       "name": "syn",
-      "version": "2.0.15",
+      "version": "2.0.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/2.0.15/download",
-          "sha256": "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+          "url": "https://crates.io/api/v1/crates/syn/2.0.17/download",
+          "sha256": "45b6ddbb36c5b969c182aec3c4a0bce7df3fbad4b77114706a49aacc80567388"
         }
       },
       "targets": [
@@ -23210,11 +23086,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -23225,7 +23101,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.15"
+        "version": "2.0.17"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -23264,11 +23140,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -23410,11 +23286,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -23438,13 +23314,13 @@
       },
       "license": "BlueOak-1.0.0"
     },
-    "syslog-tracing 0.1.0": {
+    "syslog-tracing 0.2.0": {
       "name": "syslog-tracing",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syslog-tracing/0.1.0/download",
-          "sha256": "4cf9ff1f9f8e5ba220a58bbccb0375f4cabd785f96a8683b31389cefd91be747"
+          "url": "https://crates.io/api/v1/crates/syslog-tracing/0.2.0/download",
+          "sha256": "2f890b68f60eb7e87373b3b8f1f412d2a7d90460cd18294acbc0e90ba496193e"
         }
       },
       "targets": [
@@ -23480,8 +23356,8 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.1.0"
+        "edition": "2021",
+        "version": "0.2.0"
       },
       "license": "MIT"
     },
@@ -23678,7 +23554,7 @@
               "target": "prost_types"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -23827,7 +23703,7 @@
               "target": "flex_error"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -23902,7 +23778,7 @@
               "target": "prost_types"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -24017,7 +23893,7 @@
               "target": "pin_project"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -24053,7 +23929,7 @@
               "target": "time"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -24353,15 +24229,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -24688,13 +24564,13 @@
       },
       "license": "MIT OR Apache-2.0 OR Zlib"
     },
-    "tokio 1.28.0": {
+    "tokio 1.28.1": {
       "name": "tokio",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.28.0/download",
-          "sha256": "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+          "url": "https://crates.io/api/v1/crates/tokio/1.28.1/download",
+          "sha256": "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
         }
       },
       "targets": [
@@ -24781,7 +24657,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "build_script_build"
             }
           ],
@@ -24826,7 +24702,7 @@
           ],
           "selects": {}
         },
-        "version": "1.28.0"
+        "version": "1.28.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -24872,15 +24748,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -24923,7 +24799,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             }
           ],
@@ -24966,7 +24842,7 @@
               "target": "rustls"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -25033,7 +24909,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.28.0",
+              "id": "tokio 1.28.1",
               "target": "tokio"
             },
             {
@@ -25082,7 +24958,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -25093,13 +24969,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "toml 0.7.3": {
+    "toml 0.7.4": {
       "name": "toml",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/toml/0.7.3/download",
-          "sha256": "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+          "url": "https://crates.io/api/v1/crates/toml/0.7.4/download",
+          "sha256": "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
         }
       },
       "targets": [
@@ -25129,36 +25005,36 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
-              "id": "serde_spanned 0.6.1",
+              "id": "serde_spanned 0.6.2",
               "target": "serde_spanned"
             },
             {
-              "id": "toml_datetime 0.6.1",
+              "id": "toml_datetime 0.6.2",
               "target": "toml_datetime"
             },
             {
-              "id": "toml_edit 0.19.8",
+              "id": "toml_edit 0.19.10",
               "target": "toml_edit"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.3"
+        "version": "0.7.4"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "toml_datetime 0.6.1": {
+    "toml_datetime 0.6.2": {
       "name": "toml_datetime",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/toml_datetime/0.6.1/download",
-          "sha256": "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+          "url": "https://crates.io/api/v1/crates/toml_datetime/0.6.2/download",
+          "sha256": "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
         }
       },
       "targets": [
@@ -25186,24 +25062,24 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.1"
+        "version": "0.6.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "toml_edit 0.19.8": {
+    "toml_edit 0.19.10": {
       "name": "toml_edit",
-      "version": "0.19.8",
+      "version": "0.19.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/toml_edit/0.19.8/download",
-          "sha256": "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+          "url": "https://crates.io/api/v1/crates/toml_edit/0.19.10/download",
+          "sha256": "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
         }
       },
       "targets": [
@@ -25236,15 +25112,15 @@
               "target": "indexmap"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
-              "id": "serde_spanned 0.6.1",
+              "id": "serde_spanned 0.6.2",
               "target": "serde_spanned"
             },
             {
-              "id": "toml_datetime 0.6.1",
+              "id": "toml_datetime 0.6.2",
               "target": "toml_datetime"
             },
             {
@@ -25255,7 +25131,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.19.8"
+        "version": "0.19.10"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -25382,15 +25258,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],
@@ -25642,11 +25518,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -25967,7 +25843,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "regex 1.8.1",
+              "id": "regex 1.8.3",
               "target": "regex"
             }
           ],
@@ -26201,7 +26077,7 @@
               "target": "percent_encoding"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -26321,7 +26197,7 @@
               "target": "getrandom"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             }
           ],
@@ -26415,13 +26291,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "vergen 8.1.3": {
+    "vergen 8.2.1": {
       "name": "vergen",
-      "version": "8.1.3",
+      "version": "8.2.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/vergen/8.1.3/download",
-          "sha256": "6e03272e388fb78fc79481a493424f78d77be1d55f21bcd314b5a6716e195afe"
+          "url": "https://crates.io/api/v1/crates/vergen/8.2.1/download",
+          "sha256": "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
         }
       },
       "targets": [
@@ -26475,14 +26351,14 @@
               "target": "time"
             },
             {
-              "id": "vergen 8.1.3",
+              "id": "vergen 8.2.1",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "8.1.3"
+        "version": "8.2.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -26884,11 +26760,11 @@
               "target": "once_cell"
             },
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -26995,7 +26871,7 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -27044,11 +26920,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
@@ -27257,7 +27133,7 @@
               "target": "rpassword"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -27325,7 +27201,7 @@
               "target": "base64urlsafedata"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -27414,7 +27290,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -27490,7 +27366,7 @@
               "target": "base64urlsafedata"
             },
             {
-              "id": "serde 1.0.162",
+              "id": "serde 1.0.163",
               "target": "serde"
             },
             {
@@ -29320,15 +29196,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.56",
+              "id": "proc-macro2 1.0.59",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.27",
+              "id": "quote 1.0.28",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.15",
+              "id": "syn 2.0.17",
               "target": "syn"
             }
           ],

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "74fa8a0dba288d8ddf409584c522cef460ddef75cf6a3a50c6e7914730312c6d",
+  "checksum": "db932853598ab58b88c0a63e5158b8fde4149df7d9cc4262e52a6a1fe599a3bd",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -2826,13 +2826,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "bs58 0.4.0": {
+    "bs58 0.5.0": {
       "name": "bs58",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bs58/0.4.0/download",
-          "sha256": "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+          "url": "https://crates.io/api/v1/crates/bs58/0.5.0/download",
+          "sha256": "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
         }
       },
       "targets": [
@@ -2857,8 +2857,8 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.4.0"
+        "edition": "2021",
+        "version": "0.5.0"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -3160,13 +3160,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "cbor-diag 0.1.11": {
+    "cbor-diag 0.1.12": {
       "name": "cbor-diag",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cbor-diag/0.1.11/download",
-          "sha256": "2644c5bb01d8328b218301180b84ccc6f7fce031d50e30917b07ae762a185b7b"
+          "url": "https://crates.io/api/v1/crates/cbor-diag/0.1.12/download",
+          "sha256": "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
         }
       },
       "targets": [
@@ -3188,7 +3188,7 @@
         "deps": {
           "common": [
             {
-              "id": "bs58 0.4.0",
+              "id": "bs58 0.5.0",
               "target": "bs58"
             },
             {
@@ -3204,7 +3204,7 @@
               "target": "half"
             },
             {
-              "id": "nom 5.1.3",
+              "id": "nom 7.1.3",
               "target": "nom"
             },
             {
@@ -3235,7 +3235,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.11"
+        "version": "0.1.12"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -12530,7 +12530,7 @@
               "target": "base64"
             },
             {
-              "id": "cbor-diag 0.1.11",
+              "id": "cbor-diag 0.1.12",
               "target": "cbor_diag"
             },
             {
@@ -13999,7 +13999,7 @@
         "deps": {
           "common": [
             {
-              "id": "cbor-diag 0.1.11",
+              "id": "cbor-diag 0.1.12",
               "target": "cbor_diag"
             },
             {
@@ -14126,7 +14126,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "cbor-diag 0.1.11",
+              "id": "cbor-diag 0.1.12",
               "target": "cbor_diag"
             },
             {
@@ -14480,7 +14480,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "cbor-diag 0.1.11",
+              "id": "cbor-diag 0.1.12",
               "target": "cbor_diag"
             },
             {
@@ -15402,79 +15402,6 @@
             {
               "id": "unicase 2.6.0",
               "target": "unicase"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT"
-    },
-    "nom 5.1.3": {
-      "name": "nom",
-      "version": "5.1.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/nom/5.1.3/download",
-          "sha256": "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "nom",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "nom",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "memchr 2.5.0",
-              "target": "memchr"
-            },
-            {
-              "id": "nom 5.1.3",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "5.1.3"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
             }
           ],
           "selects": {}

--- a/src/http_proxy/Cargo.toml
+++ b/src/http_proxy/Cargo.toml
@@ -13,17 +13,17 @@ name = "http_proxy"
 doc = false
 
 [dependencies]
-clap = { version = "3.2.23", features = ["derive"] }
+clap = { version = "3.2.25", features = ["derive"] }
 hex = "0.4.3"
-log-panics = { version = "2", features = ["with-backtrace"]}
+log-panics = { version = "2.1.0", features = ["with-backtrace"]}
 minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-client = { path = "../many-client", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", version = "0.1.1" } # managed by release.sh
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh
-new_mime_guess = "4.0.0"
-syslog-tracing = "0.1"
+new_mime_guess = "4.0.1"
+syslog-tracing = "0.2.0"
 tiny_http = "0.12.0"
-tracing = "0.1.29"
-tracing-subscriber = "0.3"
-tokio = { version = "1.24.1", features = [ "full" ] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+tokio = { version = "1.28.1", features = [ "full" ] }

--- a/src/idstore-export/Cargo.toml
+++ b/src/idstore-export/Cargo.toml
@@ -13,9 +13,9 @@ name = "idstore-export"
 doc = false
 
 [dependencies]
-base64 = "0.21.0"
-clap = { version = "3.2.23", features = ["derive"] }
+base64 = "0.21.2"
+clap = { version = "3.2.25", features = ["derive"] }
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
-serde = "1.0.137"
-serde_derive = "1.0.137"
-serde_json = "1.0.81"
+serde = "1.0.163"
+serde_derive = "1.0.163"
+serde_json = "1.0.96"

--- a/src/kvstore/Cargo.toml
+++ b/src/kvstore/Cargo.toml
@@ -13,10 +13,10 @@ name = "kvstore"
 doc = false
 
 [dependencies]
-clap = { version = "3.2.23", features = ["derive"] }
+clap = { version = "3.2.25", features = ["derive"] }
 hex = "0.4.3"
 indicatif = "0.17.3"
-log-panics = { version = "2", features = ["with-backtrace"]}
+log-panics = { version = "2.1.0", features = ["with-backtrace"]}
 minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-client = { path = "../many-client", version = "0.1.1" } # managed by release.sh
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
@@ -25,7 +25,7 @@ many-identity-dsa = { path = "../many-identity-dsa", features = ["ed25519", "ecd
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-syslog-tracing = "0.1"
-tracing = "0.1.29"
-tracing-subscriber = "0.3"
-tokio = { version = "1.24.1", features = [ "full" ] }
+syslog-tracing = "0.2.0"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+tokio = { version = "1.28.1", features = [ "full" ] }

--- a/src/ledger-db/Cargo.toml
+++ b/src/ledger-db/Cargo.toml
@@ -13,7 +13,7 @@ name = "ledger-db"
 doc = false
 
 [dependencies]
-clap = { version = "3.2.23", features = ["derive"] }
+clap = { version = "3.2.25", features = ["derive"] }
 hex = "0.4.3"
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -13,12 +13,12 @@ name = "ledger"
 doc = false
 
 [dependencies]
-anyhow = "1.0.69"
-clap = { version = "3.2.23", features = ["derive"] }
-crc-any = "2.4.0"
+anyhow = "1.0.71"
+clap = { version = "3.2.25", features = ["derive"] }
+crc-any = "2.4.3"
 hex = "0.4.3"
 humantime = "2.1.0"
-indicatif = "0.16.2"
+indicatif = "0.17.3"
 lazy_static = "1.4.0"
 mime_guess = "2.0.4"
 minicbor = { version = "0.19.1", features = ["derive", "std"] }
@@ -31,8 +31,8 @@ many-identity-hsm = { path = "../many-identity-hsm", version = "0.1.1" } # manag
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-regex = "1.5.4"
+regex = "1.8.3"
 rpassword = "7.2.0"
-serde_json = "1.0.91"
-tracing = "0.1.29"
-tokio = { version = "1.24.1", features = [ "full" ] }
+serde_json = "1.0.96"
+tracing = "0.1.37"
+tokio = { version = "1.28.1", features = [ "full" ] }

--- a/src/ledger/src/main.rs
+++ b/src/ledger/src/main.rs
@@ -236,7 +236,7 @@ pub(crate) fn wait_response(
 
         let progress =
             indicatif::ProgressBar::new_spinner().with_message("Waiting for async response");
-        progress.enable_steady_tick(100);
+        progress.enable_steady_tick(Duration::from_micros(100));
 
         // TODO: improve on this by using duration and thread and watchdog.
         // Wait for the server for ~60 seconds by pinging it every second.

--- a/src/many-abci/Cargo.toml
+++ b/src/many-abci/Cargo.toml
@@ -14,16 +14,16 @@ name = "many-abci"
 doc = false
 
 [dependencies]
-async-trait = "0.1.51"
-base64 = "0.21.0"
-ciborium = "0.2.0"
-clap = { version = "3.2.23", features = ["derive"] }
-coset = "0.3"
+async-trait = "0.1.68"
+base64 = "0.21.2"
+ciborium = "0.2.1"
+clap = { version = "3.2.25", features = ["derive"] }
+coset = "0.3.4"
 hex = "0.4.3"
 itertools = "0.10.5"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
-linkme = { version = "0.3.5", features = ["used_linker"] }
+linkme = { version = "0.3.9", features = ["used_linker"] }
 minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.1" } # managed by release.sh
 many-client = { path = "../many-client", version = "0.1.1" } # managed by release.sh
@@ -37,16 +37,16 @@ many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by re
 many-server = { path = "../many-server", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
 num-integer = "0.1.45"
-reqwest = "0.11.11"
-serde_json = "1.0.72"
-sha2 = "0.10.1"
-signal-hook = "0.3.13"
+reqwest = "0.11.18"
+serde_json = "1.0.96"
+sha2 = "0.10.6"
+signal-hook = "0.3.15"
 tendermint = "0.28.0"
 tendermint-abci = "0.28.0"
 tendermint-rpc = { version = "0.28.0", features = [ "http-client" ] }
 tendermint-proto = "0.28.0"
-tokio = { version = "1.24.1", features = [ "full" ] }
-tracing = "0.1.28"
+tokio = { version = "1.28.1", features = [ "full" ] }
+tracing = "0.1.37"
 
 [build-dependencies]
-vergen = { version = "8.1.0", features = ["git", "git2"] }
+vergen = { version = "8.2.1", features = ["git", "git2"] }

--- a/src/many-cli-helpers/Cargo.toml
+++ b/src/many-cli-helpers/Cargo.toml
@@ -11,11 +11,11 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.69"
-clap = { version = "3.2.23", features = ["derive"] }
-log-panics = { version = "2", features = ["with-backtrace"]}
+anyhow = "1.0.71"
+clap = { version = "3.2.25", features = ["derive"] }
+log-panics = { version = "2.1.0", features = ["with-backtrace"]}
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 minicbor = { version = "0.19.1", features = ["derive", "std", "half"] }
-syslog-tracing = "0.1.0"
+syslog-tracing = "0.2.0"
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = "0.3.17"

--- a/src/many-client-macros/Cargo.toml
+++ b/src/many-client-macros/Cargo.toml
@@ -14,6 +14,6 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.12", features = ["full", "extra-traits"] }
-quote = "1.0.26"
-proc-macro2 = "1.0.54"
+syn = { version = "2.0.17", features = ["full", "extra-traits"] }
+quote = "1.0.28"
+proc-macro2 = "1.0.56"

--- a/src/many-client/Cargo.toml
+++ b/src/many-client/Cargo.toml
@@ -9,17 +9,17 @@ repository = "https://github.com/liftedinit/many-rs.git"
 authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 
 [dependencies]
-anyhow = "1.0.44"
-async-trait = "0.1.51"
+anyhow = "1.0.71"
+async-trait = "0.1.68"
 base32 = "0.4.0"
-base64 = "0.21.0"
-coset = "0.3"
-crc-any = "2.4.0"
+base64 = "0.21.2"
+coset = "0.3.4"
+crc-any = "2.4.3"
 derive_builder = "0.12.0"
-ecdsa = "0.16.0"
-ed25519 = { version = "2.2.0", features = [ "std" ] }
+ecdsa = "0.16.7"
+ed25519 = { version = "2.2.1", features = [ "std" ] }
 ed25519-dalek = { version = "1.0.1", features = [ "std" ] }
-fixed = "1.16.0"
+fixed = "1.23.1"
 hex = "0.4.3"
 many-client-macros = { path = "../many-client-macros", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
@@ -29,19 +29,19 @@ many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by re
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
 minicbor = { version = "0.19.1", features = ["derive", "half", "std"] }
 num-derive = "0.3.3"
-num-traits = "0.2.14"
+num-traits = "0.2.15"
 num-bigint = "0.4.3"
-p256 = { version = "0.13.0", features = [ "pem", "ecdsa", "std" ] }
-pem = { version = "2.0.0", optional = true }
+p256 = { version = "0.13.2", features = [ "pem", "ecdsa", "std" ] }
+pem = { version = "2.0.1", optional = true }
 many-server = { path = "../many-server", version = "0.1.1" } # managed by release.sh
-rand = "0.8.4"
-regex = "1.5.4"
-reqwest = { version = "0.11.5", features = ["blocking"] }
-serde = { version = "1.0.130" }
-sha3 = "0.10.6"
+rand = "0.8.5"
+regex = "1.8.3"
+reqwest = { version = "0.11.18", features = ["blocking"] }
+serde = { version = "1.0.163" }
+sha3 = "0.10.8"
 static_assertions = "1.1.0"
-tracing = "0.1.29"
-tokio = { version = "1.24.1", features = [ "full" ] }
+tracing = "0.1.37"
+tokio = { version = "1.28.1", features = [ "full" ] }
 tiny_http = "0.12.0"
 
 [features]

--- a/src/many-error/Cargo.toml
+++ b/src/many-error/Cargo.toml
@@ -11,12 +11,12 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-backtrace = { version = "0.3.66", optional = true }
+backtrace = { version = "0.3.67", optional = true }
 minicbor = { version = "0.19.1", optional = true, features = ["alloc"] }
 num-derive = "0.3.3"
-num-traits = "0.2.14"
-regex = "1.6.0"
-tracing = { version = "0.1.35", optional = true }
+num-traits = "0.2.15"
+regex = "1.8.3"
+tracing = { version = "0.1.37", optional = true }
 
 [features]
 default = ["minicbor"]

--- a/src/many-identity-dsa/Cargo.toml
+++ b/src/many-identity-dsa/Cargo.toml
@@ -13,26 +13,26 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 [dependencies]
 base32 = "0.4.0"
 crc-any = "2.4.3"
-coset = { version = "0.3.2", optional = true }
-ed25519 = { version = "2.1.0", features = [ "alloc", "std", "pem" ], optional = true }
+coset = { version = "0.3.4", optional = true }
+ed25519 = { version = "2.2.1", features = [ "alloc", "std", "pem" ], optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
 minicbor = { version = "0.19.1", optional = true }
-once_cell = "1.10"
-p256 = { version = "0.13.0", features = [ "alloc", "pem", "ecdsa", "std" ] }
-rand = { version = "0.8", optional = true }
-rand_07 = { package = "rand", version = "0.7", optional = true }  # Version compatible with ed25519-dalek
-serde = "1.0.139"
-sha2 = "0.10.2"
-sha3 = "0.10.6"
-tracing = "0.1.29"
+once_cell = "1.17.1"
+p256 = { version = "0.13.2", features = [ "alloc", "pem", "ecdsa", "std" ] }
+rand = { version = "0.8.5", optional = true }
+rand_07 = { package = "rand", version = "0.7.3", optional = true }  # Version compatible with ed25519-dalek
+serde = "1.0.163"
+sha2 = "0.10.6"
+sha3 = "0.10.8"
+tracing = "0.1.37"
 
 [dev-dependencies]
-proptest = "1.0.0"
+proptest = "1.2.0"
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = ".", features = [ "default", "ecdsa", "ed25519", "serde", "testing" ], version = "0.1.1" } # managed by release.sh
-serde_test = "1.0.139"
+serde_test = "1.0.163"
 
 [features]
 default = ["coset", "minicbor"]

--- a/src/many-identity-hsm/Cargo.toml
+++ b/src/many-identity-hsm/Cargo.toml
@@ -11,14 +11,14 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-asn1 = "0.13.0"
-coset = "0.3.2"
+asn1 = "0.15.2"
+coset = "0.3.4"
 cryptoki = { version = "0.3.1", features = ["generate-bindings"] }
 hex = "0.4.3"
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = ["ecdsa"], version = "0.1.1" } # managed by release.sh
-once_cell = "1.13.0"
-p256 = "0.13.0"
-sha2 = "0.10.2"
-tracing = "0.1.36"
+once_cell = "1.17.1"
+p256 = "0.13.2"
+sha2 = "0.10.6"
+tracing = "0.1.37"

--- a/src/many-identity-webauthn/Cargo.toml
+++ b/src/many-identity-webauthn/Cargo.toml
@@ -12,9 +12,9 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 
 [dependencies]
 authenticator-ctap2-2021 = { version = "0.3.2-dev.1", optional = true, default-features = false, features = ["crypto_openssl"] }
-base64 = "0.21.0"
-base64urlsafedata = { version = "0.1.2", optional = true }
-coset = "0.3.2"
+base64 = "0.21.2"
+base64urlsafedata = { version = "0.1.3", optional = true }
+coset = "0.3.4"
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = ["ecdsa"], version = "0.1.1" } # managed by release.sh
@@ -22,14 +22,14 @@ many-modules = { path = "../many-modules", optional = true, version = "0.1.1" } 
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
 minicbor = "0.19.1"
-once_cell = "1.13.0"
+once_cell = "1.17.1"
 rand = { version = "0.8.5", optional = true }
 rpassword = { version = "7.2.0", optional = true }
-serde = "1.0.142"
+serde = "1.0.163"
 serde_cbor = { version = "0.11.2", optional = true }
-serde_json = "1.0.83"
-sha2 = "0.10.2"
-tracing = "0.1.36"
+serde_json = "1.0.96"
+sha2 = "0.10.6"
+tracing = "0.1.37"
 webauthn-authenticator-rs = { version = "0.4.9", optional = true, features = ["u2fhid", "usb"] }
 webauthn-rs = { version = "0.4.8", optional = true }
 webauthn-rs-proto = { version = "0.4.9", optional = true }

--- a/src/many-identity/Cargo.toml
+++ b/src/many-identity/Cargo.toml
@@ -14,19 +14,19 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 base32 = "0.4.0"
 crc-any = "2.4.3"
-coset = { version = "0.3.2", optional = true }
+coset = { version = "0.3.4", optional = true }
 hex = "0.4.3"
 minicbor = { version = "0.19.1", optional = true }
-once_cell = "1.10"
-serde = "1.0.139"
-sha3 = "0.10.6"
+once_cell = "1.17.1"
+serde = "1.0.163"
+sha3 = "0.10.8"
 static_assertions = "1.1.0"
-tracing = "0.1.29"
+tracing = "0.1.37"
 
 [dev-dependencies]
 many-identity = { path = ".", features = [ "serde", "testing" ], version = "0.1.1" } # managed by release.sh
-proptest = "1.0.0"
-serde_test = "1.0.139"
+proptest = "1.2.0"
+serde_test = "1.0.163"
 
 [features]
 default = ["coset", "minicbor"]

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -14,9 +14,9 @@ name = "many-kvstore"
 doc = false
 
 [dependencies]
-async-trait = "0.1.51"
-clap = { version = "3.2.23", features = ["derive"] }
-coset = "0.3"
+async-trait = "0.1.68"
+clap = { version = "3.2.25", features = ["derive"] }
+coset = "0.3.4"
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
 hex = { version = "0.4.3", features = ["serde"] }
 json5 = "0.4.1"
@@ -31,19 +31,19 @@ many-modules = { path = "../many-modules", version = "0.1.1" } # managed by rele
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-server = { path = "../many-server", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-serde = "1.0.130"
-sha3 = "0.10.6"
-signal-hook = "0.3.13"
+serde = "1.0.163"
+sha3 = "0.10.8"
+signal-hook = "0.3.15"
 strum = "0.24.1"
-tokio = { version = "1.24.1", features = [ "full" ] }
-tracing = "0.1.28"
+tokio = { version = "1.28.1", features = [ "full" ] }
+tracing = "0.1.37"
 
 [dev-dependencies]
-async-channel = "1.8"
-once_cell = "1.14.0"
+async-channel = "1.8.0"
+once_cell = "1.17.1"
 many-identity = { path = "../many-identity", features = ["default", "serde", "testing"], version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = [ "ed25519", "testing" ], version = "0.1.1" } # managed by release.sh
-tempfile = "3.3.0"
+tempfile = "3.5.0"
 
 [build-dependencies]
-vergen = { version = "8.1.0", features = ["git", "git2"] }
+vergen = { version = "8.2.1", features = ["git", "git2"] }

--- a/src/many-ledger/Cargo.toml
+++ b/src/many-ledger/Cargo.toml
@@ -14,21 +14,21 @@ name = "many-ledger"
 doc = false
 
 [dependencies]
-async-channel = "1.8"
-async-trait = "0.1.51"
-base64 = "0.21.0"
-bip39-dict = "0.1"
-clap = { version = "3.2.23", features = ["derive"] }
-coset = "0.3"
+async-channel = "1.8.0"
+async-trait = "0.1.68"
+base64 = "0.21.2"
+bip39-dict = "0.1.1"
+clap = { version = "3.2.25", features = ["derive"] }
+coset = "0.3.4"
 const_format = "0.2.30"
-fixed = "1.11.0"
+fixed = "1.23.1"
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
 hex = "0.4.3"
-itertools = "0.10.3"
+itertools = "0.10.5"
 json5 = "0.4.1"
-linkme = { version = "0.3.5", features = ["used_linker"] }
+linkme = { version = "0.3.9", features = ["used_linker"] }
 num-bigint = "0.4.3"
-num-traits = "0.2.14"
+num-traits = "0.2.15"
 minicbor = { version = "0.19.1", features = ["derive", "std"] }
 many-cli-helpers = { path = "../many-cli-helpers", version = "0.1.1" } # managed by release.sh
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
@@ -40,27 +40,27 @@ many-modules = { path = "../many-modules", version = "0.1.1" } # managed by rele
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-server = { path = "../many-server", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-rand = "0.8"
-serde = "1.0.130"
-serde_json = "1.0.72"
-sha3 = "0.10.6"
-signal-hook = "0.3.13"
+rand = "0.8.5"
+serde = "1.0.163"
+serde_json = "1.0.96"
+sha3 = "0.10.8"
+signal-hook = "0.3.15"
 strum = "0.24.1"
-tokio = { version = "1.24.1", features = [ "full" ] }
-tracing = "0.1.28"
-typenum = "1.15.0"
+tokio = { version = "1.28.1", features = [ "full" ] }
+tracing = "0.1.37"
+typenum = "1.16.0"
 
 [dev-dependencies]
 cucumber = { version = "0.19.1", features = ["libtest"] }
-once_cell = "1.12"
+once_cell = "1.17.1"
 many-identity = { path = "../many-identity", features = ["default", "serde", "testing"], version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = [ "ed25519", "testing" ], version = "0.1.1" } # managed by release.sh
 many-ledger = { path = ".", features = ["balance_testing", "migration_testing", "disable_token_sender_check"]}
 many-modules = { path = "../many-modules", features = ["cucumber"], version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", features = ["cucumber"], version = "0.1.1" } # managed by release.sh
-proptest = "1"
-tempfile = "3.3.0"
-tokio = "1.13.0"
+proptest = "1.2.0"
+tempfile = "3.5.0"
+tokio = "1.28.1"
 many-ledger-test-utils = { path = "test-utils", version = "0.1.1" } # managed by release.sh
 many-ledger-test-macros = { path = "test-macros", version = "0.1.1" } # managed by release.sh
 
@@ -85,7 +85,7 @@ path = "tests/ledger_tokens/remove_token_ext_info.rs"
 harness = false
 
 [build-dependencies]
-vergen = { version = "8.1.0", features = ["git", "git2"] }
+vergen = { version = "8.2.1", features = ["git", "git2"] }
 
 [features]
 balance_testing=[]                  # Enable balance initialization from the CLI

--- a/src/many-ledger/test-macros/Cargo.toml
+++ b/src/many-ledger/test-macros/Cargo.toml
@@ -13,5 +13,5 @@ publish = false
 proc-macro = true
 
 [dependencies]
-quote = "1.0.26"
-syn = "2.0.12"
+quote = "1.0.28"
+syn = "2.0.17"

--- a/src/many-ledger/test-utils/Cargo.toml
+++ b/src/many-ledger/test-utils/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/liftedinit/many-framework"
 publish = false
 
 [dependencies]
-async-channel = "1.8"
-coset = "0.3"
+async-channel = "1.8.0"
+coset = "0.3.4"
 cucumber = { version = "0.19.1", features = ["libtest"] }
-itertools = "0.10.3"
+itertools = "0.10.5"
 many-error = { path = "../../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../../many-identity", features = ["default", "serde", "testing"], version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../../many-identity-dsa", features = ["ed25519", "ecdsa", "testing"], version = "0.1.1" } # managed by release.sh
@@ -24,8 +24,8 @@ many-protocol = { path = "../../many-protocol", version = "0.1.1" } # managed by
 many-types = { path = "../../many-types", features = ["cucumber"], version = "0.1.1" } # managed by release.sh
 merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
 minicbor = { version = "0.19.1", features = ["derive", "std"] }
-once_cell = "1.12"
-proptest = "1"
-serde_json = "1.0.72"
-tempfile = "3.3.0"
-tracing = "0.1.28"
+once_cell = "1.17.1"
+proptest = "1.2.0"
+serde_json = "1.0.96"
+tempfile = "3.5.0"
+tracing = "0.1.37"

--- a/src/many-macros/Cargo.toml
+++ b/src/many-macros/Cargo.toml
@@ -13,9 +13,9 @@ proc-macro = true
 
 [dependencies]
 inflections = "1.1.1"
-proc-macro2 = "1.0.54"
-quote = "1.0.26"
-serde = "1.0.134"
+proc-macro2 = "1.0.56"
+quote = "1.0.28"
+serde = "1.0.163"
 serde_tokenstream = "0.2.0"
-syn = "2.0.12"
+syn = "2.0.17"
 

--- a/src/many-migration/Cargo.toml
+++ b/src/many-migration/Cargo.toml
@@ -13,10 +13,10 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 [dependencies]
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 minicbor = { version = "0.19.1", features = ["derive"] }
-serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.87"
-strum = { version = "0.24", features = ["derive"] }
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = "1.0.96"
+strum = { version = "0.24.1", features = ["derive"] }
 tracing = "0.1.37"
 
 [dev-dependencies]
-linkme = { version = "0.3.5", features = ["used_linker"] }
+linkme = { version = "0.3.9", features = ["used_linker"] }

--- a/src/many-mock/Cargo.toml
+++ b/src/many-mock/Cargo.toml
@@ -11,11 +11,11 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
-coset = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-toml = "0.7.3"
-regex = "1.5.4"
+async-trait = "0.1.68"
+coset = "0.3.4"
+serde = { version = "1.0.163", features = ["derive"] }
+toml = "0.7.4"
+regex = "1.8.3"
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = ["ed25519"], version = "0.1.1" } # managed by release.sh
@@ -27,11 +27,11 @@ cbor-diag = "0.1"
 
 [dev-dependencies]
 cucumber = { version = "0.19.1", features = ["libtest"] }
-futures = "0.3"
+futures = "0.3.28"
 many-client = { path = "../many-client", version = "0.1.1" } # managed by release.sh
-serde_json = "1.0"
-ciborium = "0.2"
-tokio = "1.24.1"
+serde_json = "1.0.96"
+ciborium = "0.2.1"
+tokio = "1.28.1"
 
 [[test]]
 name = "integration"

--- a/src/many-mock/Cargo.toml
+++ b/src/many-mock/Cargo.toml
@@ -23,7 +23,7 @@ many-identity-webauthn = { path = "../many-identity-webauthn", version = "0.1.1"
 many-modules = { path = "../many-modules", version = "0.1.1" } # managed by release.sh
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-server = { path = "../many-server", version = "0.1.1" } # managed by release.sh
-cbor-diag = "0.1"
+cbor-diag = "0.1.12"
 
 [dev-dependencies]
 cucumber = { version = "0.19.1", features = ["libtest"] }

--- a/src/many-modules/Cargo.toml
+++ b/src/many-modules/Cargo.toml
@@ -28,7 +28,7 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 
 [dev-dependencies]
-cbor-diag = "0.1.11"
+cbor-diag = "0.1.12"
 many-identity = { path = "../many-identity", features = ["raw", "testing"], version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = ["ed25519", "testing"], version = "0.1.1" } # managed by release.sh
 mockall = "0.11.4"

--- a/src/many-modules/Cargo.toml
+++ b/src/many-modules/Cargo.toml
@@ -16,14 +16,14 @@ many-identity = { path = "../many-identity", version = "0.1.1" } # managed by re
 many-macros = { path = "../many-macros", version = "0.1.1" } # managed by release.sh
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-async-channel = "1.8"
-async-trait = "0.1.56"
-coset = "0.3.2"
+async-channel = "1.8.0"
+async-trait = "0.1.68"
+coset = "0.3.4"
 derive_builder = "0.12.0"
 hex = "0.4.3"
 minicbor = { version = "0.19.1", features = ["derive"] }
 num-bigint = "0.4.3"
-num_enum = "0.5.7"
+num_enum = "0.6.1"
 strum = "0.24.1"
 strum_macros = "0.24.3"
 
@@ -31,10 +31,10 @@ strum_macros = "0.24.3"
 cbor-diag = "0.1.11"
 many-identity = { path = "../many-identity", features = ["raw", "testing"], version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = ["ed25519", "testing"], version = "0.1.1" } # managed by release.sh
-mockall = "0.11.1"
-once_cell = "1.13.0"
-proptest = "1.0.0"
-smol = "1.2.5"
+mockall = "0.11.4"
+once_cell = "1.17.1"
+proptest = "1.2.0"
+smol = "1.3.0"
 
 [features]
 cucumber = ["many-types/cucumber"]

--- a/src/many-protocol/Cargo.toml
+++ b/src/many-protocol/Cargo.toml
@@ -14,19 +14,19 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
-async-channel = "1.8"
-base64 = "0.21.0"
-coset = "0.3.2"
+async-channel = "1.8.0"
+base64 = "0.21.2"
+coset = "0.3.4"
 derive_builder = "0.12.0"
 hex = "0.4.3"
 minicbor = { version = "0.19.1", features = ["derive", "std"] }
 num-derive = "0.3.3"
-num-traits = "0.2.14"
+num-traits = "0.2.15"
 num-bigint = "0.4.3"
-serde = "1.0.139"
-tracing = "0.1.35"
+serde = "1.0.163"
+tracing = "0.1.37"
 url = "2.3.1"
 
 [dev-dependencies]
-once_cell = "1.13.0"
-proptest = "1.0.0"
+once_cell = "1.17.1"
+proptest = "1.2.0"

--- a/src/many-server/Cargo.toml
+++ b/src/many-server/Cargo.toml
@@ -12,15 +12,15 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 name = "many_server"
 
 [dependencies]
-anyhow = "1.0.44"
-async-trait = "0.1.51"
-backtrace = { version = "0.3", optional = true }
+anyhow = "1.0.71"
+async-trait = "0.1.68"
+backtrace = { version = "0.3.67", optional = true }
 base32 = "0.4.0"
-base64 = "0.21.0"
-coset = "0.3"
-crc-any = "2.4.0"
+base64 = "0.21.2"
+coset = "0.3.4"
+crc-any = "2.4.3"
 derive_builder = "0.12.0"
-fixed = "1.16.0"
+fixed = "1.23.1"
 hex = "0.4.3"
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", features = ["coset", "raw"], version = "0.1.1" } # managed by release.sh
@@ -30,26 +30,26 @@ many-types = { path = "../many-types", version = "0.1.1" } # managed by release.
 minicbor = { version = "0.19.1", features = ["derive", "half", "std"] }
 num-bigint = "0.4.3"
 num-derive = "0.3.3"
-num-traits = "0.2.14"
-once_cell = "1.10"
-pem = { version = "2.0.0", optional = true }
+num-traits = "0.2.15"
+once_cell = "1.17.1"
+pem = { version = "2.0.1", optional = true }
 many-macros = { path = "../many-macros", version = "0.1.1" } # managed by release.sh
-regex = "1.5.4"
-serde = { version = "1.0.130" }
-sha3 = "0.10.6"
+regex = "1.8.3"
+serde = { version = "1.0.163" }
+sha3 = "0.10.8"
 static_assertions = "1.1.0"
-strum = "0.24.0"
-strum_macros = "0.24"
-tracing = "0.1.29"
+strum = "0.24.1"
+strum_macros = "0.24.3"
+tracing = "0.1.37"
 tiny_http = "0.12.0"
 
 [dev-dependencies]
 many-server = { path = ".", features = ["testing"], version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", features = ["coset", "raw", "testing"], version = "0.1.1" } # managed by release.sh
 many-identity-dsa = { path = "../many-identity-dsa", features = ["ed25519", "testing"], version = "0.1.1" } # managed by release.sh
-proptest = "1.0.0"
-semver = "1.0"
-smol = "1.2.5"
+proptest = "1.2.0"
+semver = "1.0.17"
+smol = "1.3.0"
 
 [features]
 default = []

--- a/src/many-types/Cargo.toml
+++ b/src/many-types/Cargo.toml
@@ -13,22 +13,22 @@ authors = ["The Lifted Initiative <crates@liftedinit.org>"]
 [dependencies]
 many-error = { path = "../many-error", version = "0.1.1" } # managed by release.sh
 many-identity = { path = "../many-identity", version = "0.1.1" } # managed by release.sh
-base64 = "0.21.0"
-coset = "0.3.2"
-derive_more = "0.99"
-fixed = "1.16.0"
+base64 = "0.21.2"
+coset = "0.3.4"
+derive_more = "0.99.17"
+fixed = "1.23.1"
 hex = "0.4.3"
 minicbor = { version = "0.19.1", features = ["derive", "std", "half"] }
 num-derive = "0.3.3"
-num-traits = "0.2.14"
+num-traits = "0.2.15"
 num-bigint = "0.4.3"
-proptest = { version = "1.0.0", optional = true }
-serde = "1.0.139"
+proptest = { version = "1.2.0", optional = true }
+serde = "1.0.163"
 
 [dev-dependencies]
 cbor-diag = "0.1.11"
 many-types = { path = ".", features = ["proptest"], version = "0.1.1" } # managed by release.sh
-serde_test = "1.0.139"
+serde_test = "1.0.163"
 
 [features]
 cucumber = []

--- a/src/many-types/Cargo.toml
+++ b/src/many-types/Cargo.toml
@@ -26,7 +26,7 @@ proptest = { version = "1.2.0", optional = true }
 serde = "1.0.163"
 
 [dev-dependencies]
-cbor-diag = "0.1.11"
+cbor-diag = "0.1.12"
 many-types = { path = ".", features = ["proptest"], version = "0.1.1" } # managed by release.sh
 serde_test = "1.0.163"
 

--- a/src/many/Cargo.toml
+++ b/src/many/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = "1.0.71"
 async-recursion = "1.0.4"
 atty = "0.2.14"
 base64 = "0.21.2"
-cbor-diag = "0.1.9"
+cbor-diag = "0.1.12"
 clap = { version = "3.2.25", features = [ "derive" ] }
 coset = "0.3.4"
 hex = "0.4.3"

--- a/src/many/Cargo.toml
+++ b/src/many/Cargo.toml
@@ -25,18 +25,18 @@ many-modules = { path = "../many-modules", version = "0.1.1" } # managed by rele
 many-protocol = { path = "../many-protocol", version = "0.1.1" } # managed by release.sh
 many-types = { path = "../many-types", version = "0.1.1" } # managed by release.sh
 many-server = { path = "../many-server", version = "0.1.1" } # managed by release.sh
-anyhow = "1.0.57"
-async-recursion = "1.0"
+anyhow = "1.0.71"
+async-recursion = "1.0.4"
 atty = "0.2.14"
-base64 = "0.21.0"
+base64 = "0.21.2"
 cbor-diag = "0.1.9"
-clap = { version = "3.2.23", features = [ "derive" ] }
-coset = "0.3"
+clap = { version = "3.2.25", features = [ "derive" ] }
+coset = "0.3.4"
 hex = "0.4.3"
 minicbor = { version = "0.19.1", features = ["derive", "half", "std"] }
 rand = "0.8.5"
 rpassword = "7.2.0"
-tracing = "0.1.29"
-tracing-subscriber = "0.3.15"
-tokio = { version = "1.24.1", features = [ "full" ] }
-url = "2.2.2"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+tokio = { version = "1.28.1", features = [ "full" ] }
+url = "2.3.1"


### PR DESCRIPTION
Update/fix crate versions
- `clap` = `3.2.25`
- `log-panics` = `2.1.0`
- `new_mime_guess` = `4.0.1`
- `syslog-tracing` = `0.2.0`
- `tracing` = `0.1.37`
- `tracing-subscriber` = `0.3.17`
- `tokio` = `1.28.1`
- `base64` = `0.21.2`
- `serde` = `1.0.163`
- `serde_derive` = `1.0.163`
- `serde_json` = `1.0.96`
- `anyhow` = `1.0.71`
- `crc-any` = `2.4.3`
- `indicatif` = `0.17.3`
- `regex` = `1.8.3`
- `async-trait` = `0.1.68`
- `ciborium` = `0.2.1`
- `coset` = `0.3.4`
- `linkme` to `0.3.9`
- `reqwest` = `0.11.18`
- `sha2` = `0.10.6`
- `signal-hook` = `0.3.15`
- `vergen` = `8.2.1`
- `syn` = `2.0.17`
- `quote` = `1.0.28`
- `proc-macro2` = `1.0.56`
- `ecdsa` = `0.16.7`
- `ed25519` = `2.2.1`
- `fixed` = `1.23.1`
- `num-traits` = `0.2.15`
- `p256` = `0.13.2`
- `pem` = `2.0.1`
- `rand` = `0.8.5`
- `regex` = `1.8.3`
- `sha3` = `0.10.8`
- `backtrace` = `0.3.67`
- `once_cell` = `1.17.1`
- `rand_07` = `0.7.3`
- `asn1` = `0.15.2`
- `base64urlsafedata` = `0.1.3`
- `proptest` = `1.2.0`
- `serde_test` = `1.0.163`
- `async-channel` = `1.8.0`
- `tempfile` = `3.5.0`
- `bip39-dict` = `0.1.1`
- `itertools` = `0.10.5`
- `strum` = `0.24.1`
- `toml` = `0.7.4`
- `futures` = `0.3.28`
- `ciborium` = `0.2.1`
- `num_enum` = `0.6.1`
- `mockall` = `0.11.4`
- `smol` = `1.3.0`
- `async-recursion` = `1.0.4`
- `derive_more` = `0.99.17`
- `strum_macros` = `0.24.3`
- `cbor-diag` = `0.1.12`


