### PR TITLE
feat: update maximum key/value length

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1418,6 +1418,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,7 +2045,7 @@ version = "0.1.1"
 dependencies = [
  "base64 0.21.0",
  "clap 3.2.25",
- "merk",
+ "merk 2.0.0 (git+https://github.com/liftedinit/merk.git?rev=857bf81963d9282ab03438da5013e1f816bd9da1#857bf81963d9282ab03438da5013e1f816bd9da1)",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2264,7 +2286,7 @@ dependencies = [
  "hex",
  "many-modules",
  "many-types",
- "merk",
+ "merk 2.0.0 (git+https://github.com/liftedinit/merk.git?rev=857bf81963d9282ab03438da5013e1f816bd9da1#857bf81963d9282ab03438da5013e1f816bd9da1)",
  "minicbor",
 ]
 
@@ -2668,7 +2690,7 @@ dependencies = [
  "many-protocol",
  "many-server",
  "many-types",
- "merk",
+ "merk 2.0.0-ll (git+https://github.com/liftedinit/merk.git?rev=532eb097ec50f3553c5294971c152b4e7c7d4731#532eb097ec50f3553c5294971c152b4e7c7d4731)",
  "minicbor",
  "num-bigint",
  "once_cell",
@@ -2712,7 +2734,7 @@ dependencies = [
  "many-protocol",
  "many-server",
  "many-types",
- "merk",
+ "merk 2.0.0 (git+https://github.com/liftedinit/merk.git?rev=857bf81963d9282ab03438da5013e1f816bd9da1#857bf81963d9282ab03438da5013e1f816bd9da1)",
  "minicbor",
  "num-bigint",
  "num-traits",
@@ -2755,7 +2777,7 @@ dependencies = [
  "many-modules",
  "many-protocol",
  "many-types",
- "merk",
+ "merk 2.0.0 (git+https://github.com/liftedinit/merk.git?rev=857bf81963d9282ab03438da5013e1f816bd9da1#857bf81963d9282ab03438da5013e1f816bd9da1)",
  "minicbor",
  "once_cell",
  "proptest",
@@ -2940,6 +2962,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "merk"
+version = "2.0.0-ll"
+source = "git+https://github.com/liftedinit/merk.git?rev=532eb097ec50f3553c5294971c152b4e7c7d4731#532eb097ec50f3553c5294971c152b4e7c7d4731"
+dependencies = [
+ "byteorder",
+ "colored",
+ "ed",
+ "failure",
+ "hex",
+ "num_cpus",
+ "rand 0.8.5",
+ "rocksdb",
+ "sha2 0.10.6",
+ "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "merk"
 version = "2.0.0-ll"
-source = "git+https://github.com/liftedinit/merk.git?rev=1c781a3aa3eb7f015740d5e89a1754ba31a9fe52#1c781a3aa3eb7f015740d5e89a1754ba31a9fe52"
+source = "git+https://github.com/liftedinit/merk.git?rev=532eb097ec50f3553c5294971c152b4e7c7d4731#532eb097ec50f3553c5294971c152b4e7c7d4731"
 dependencies = [
  "byteorder",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,7 +2045,7 @@ version = "0.1.1"
 dependencies = [
  "base64 0.21.0",
  "clap 3.2.23",
- "merk",
+ "merk 2.0.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2264,7 +2286,7 @@ dependencies = [
  "hex",
  "many-modules",
  "many-types",
- "merk",
+ "merk 2.0.0",
  "minicbor",
 ]
 
@@ -2668,7 +2690,7 @@ dependencies = [
  "many-protocol",
  "many-server",
  "many-types",
- "merk",
+ "merk 2.0.0-ll",
  "minicbor",
  "num-bigint",
  "once_cell",
@@ -2712,7 +2734,7 @@ dependencies = [
  "many-protocol",
  "many-server",
  "many-types",
- "merk",
+ "merk 2.0.0",
  "minicbor",
  "num-bigint",
  "num-traits",
@@ -2755,7 +2777,7 @@ dependencies = [
  "many-modules",
  "many-protocol",
  "many-types",
- "merk",
+ "merk 2.0.0",
  "minicbor",
  "once_cell",
  "proptest",
@@ -2940,6 +2962,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "merk"
+version = "2.0.0-ll"
+source = "git+https://github.com/liftedinit/merk.git?rev=1c781a3aa3eb7f015740d5e89a1754ba31a9fe52#1c781a3aa3eb7f015740d5e89a1754ba31a9fe52"
+dependencies = [
+ "byteorder",
+ "colored",
+ "ed",
+ "failure",
+ "hex",
+ "num_cpus",
+ "rand 0.8.5",
+ "rocksdb",
+ "sha2 0.10.6",
+ "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6f2fc5fd39682d2b2176e2f16cd98542b3d25b8d3d2584d395407dd502b93ba9",
+  "checksum": "c0018d77ec221c6758da158cee2983a7d54d8cde11728dc537b079d75b35916b",
   "crates": {
     "addr2line 0.19.0": {
       "name": "addr2line",
@@ -7404,6 +7404,133 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "failure 0.1.8": {
+      "name": "failure",
+      "version": "0.1.8",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/failure/0.1.8/download",
+          "sha256": "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "failure",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "failure",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "backtrace",
+            "default",
+            "derive",
+            "failure_derive",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "backtrace 0.3.67",
+              "target": "backtrace"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "failure_derive 0.1.8",
+              "target": "failure_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.1.8"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "failure_derive 0.1.8": {
+      "name": "failure_derive",
+      "version": "0.1.8",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/failure_derive/0.1.8/download",
+          "sha256": "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "failure_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "failure_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "failure_derive 0.1.8",
+              "target": "build_script_build"
+            },
+            {
+              "id": "proc-macro2 1.0.56",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.27",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.109",
+              "target": "syn"
+            },
+            {
+              "id": "synstructure 0.12.6",
+              "target": "synstructure"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.1.8"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "fastrand 1.9.0": {
       "name": "fastrand",
       "version": "1.9.0",
@@ -13548,7 +13675,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "merk 2.0.0",
+              "id": "merk 2.0.0-ll",
               "target": "merk"
             },
             {
@@ -14798,6 +14925,104 @@
         },
         "edition": "2018",
         "version": "2.0.0"
+      },
+      "license": "MIT"
+    },
+    "merk 2.0.0-ll": {
+      "name": "merk",
+      "version": "2.0.0-ll",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/liftedinit/merk.git",
+          "commitish": {
+            "Rev": "532eb097ec50f3553c5294971c152b4e7c7d4731"
+          }
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "merk",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "merk",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "byteorder",
+            "colored",
+            "default",
+            "ed",
+            "failure",
+            "full",
+            "hex",
+            "num_cpus",
+            "rand",
+            "rocksdb",
+            "time",
+            "verify"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "byteorder 1.4.3",
+              "target": "byteorder"
+            },
+            {
+              "id": "colored 2.0.0",
+              "target": "colored"
+            },
+            {
+              "id": "ed 0.3.0",
+              "target": "ed"
+            },
+            {
+              "id": "failure 0.1.8",
+              "target": "failure"
+            },
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "num_cpus 1.15.0",
+              "target": "num_cpus"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            },
+            {
+              "id": "rocksdb 0.19.0",
+              "target": "rocksdb"
+            },
+            {
+              "id": "sha2 0.10.6",
+              "target": "sha2"
+            },
+            {
+              "id": "thiserror 1.0.40",
+              "target": "thiserror"
+            },
+            {
+              "id": "time 0.3.21",
+              "target": "time"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "2.0.0-ll"
       },
       "license": "MIT"
     },

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 async-trait = "0.1.51"
 clap = { version = "3.2.23", features = ["derive"] }
 coset = "0.3"
-merk = { git = "https://github.com/liftedinit/merk.git", rev = "857bf81963d9282ab03438da5013e1f816bd9da1" }
+merk = { git = "https://github.com/liftedinit/merk.git", rev = "532eb097ec50f3553c5294971c152b4e7c7d4731" }
 hex = { version = "0.4.3", features = ["serde"] }
 json5 = "0.4.1"
 lazy_static = "1.4.0"

--- a/src/many-kvstore/src/module.rs
+++ b/src/many-kvstore/src/module.rs
@@ -208,8 +208,12 @@ impl KvStoreModuleBackend for KvStoreModuleImpl {
 
 impl KvStoreCommandsModuleBackend for KvStoreModuleImpl {
     fn put(&mut self, sender: &Address, args: PutArgs) -> Result<PutReturn, ManyError> {
-        let key: Vec<u8> = args.key.into();
-        let owner = if let Some(alternative_owner) = args.alternative_owner {
+        let PutArgs {
+            key,
+            value,
+            alternative_owner,
+        } = args;
+        let owner = if let Some(alternative_owner) = alternative_owner {
             self.validate_alternative_owner(
                 sender,
                 &alternative_owner,
@@ -220,22 +224,26 @@ impl KvStoreCommandsModuleBackend for KvStoreModuleImpl {
             *sender
         };
 
-        self.verify_acl(&owner, key.clone())?;
+        self.verify_acl(&owner, &key)?;
 
         let meta = KvStoreMetadata {
             owner,
             disabled: Some(Either::Left(false)),
         };
-        self.storage.put(&meta, &key, args.value.into())?;
+        self.storage.put(&meta, &key, value.into())?;
         Ok(PutReturn {})
     }
 
     fn disable(&mut self, sender: &Address, args: DisableArgs) -> Result<DisableReturn, ManyError> {
-        if self.storage.get(&args.key)?.is_none() {
+        let DisableArgs {
+            key,
+            alternative_owner,
+            reason,
+        } = args;
+        if self.storage.get(&key)?.is_none() {
             return Err(error::cannot_disable_empty_key());
         }
-        let key: Vec<u8> = args.key.into();
-        let owner = if let Some(ref alternative_owner) = args.alternative_owner {
+        let owner = if let Some(ref alternative_owner) = alternative_owner {
             self.validate_alternative_owner(
                 sender,
                 alternative_owner,
@@ -246,9 +254,9 @@ impl KvStoreCommandsModuleBackend for KvStoreModuleImpl {
             sender
         };
 
-        self.verify_acl(owner, key.clone())?;
+        self.verify_acl(owner, &key)?;
 
-        let maybe_reason = if let Some(reason) = args.reason {
+        let maybe_reason = if let Some(reason) = reason {
             Either::Right(reason)
         } else {
             Either::Left(true)
@@ -297,7 +305,7 @@ impl KvStoreTransferModuleBackend for KvStoreModuleImpl {
             sender
         };
 
-        self.verify_acl(owner, key.clone())?;
+        self.verify_acl(owner, &key)?;
 
         // We allow transferring a disabled key, and keep the same reason.
         let meta = KvStoreMetadata {

--- a/src/many-kvstore/src/module/account.rs
+++ b/src/many-kvstore/src/module/account.rs
@@ -310,9 +310,9 @@ impl KvStoreModuleImpl {
     }
 
     /// Verify if user is permitted to access the value at the given key
-    pub(crate) fn verify_acl(&self, sender: &Address, key: Vec<u8>) -> Result<(), ManyError> {
+    pub(crate) fn verify_acl(&self, sender: &Address, key: &[u8]) -> Result<(), ManyError> {
         // Get ACL, if it exists
-        if let Some(meta_cbor) = self.storage.get_metadata(&key)? {
+        if let Some(meta_cbor) = self.storage.get_metadata(key)? {
             // Decode ACL
             let meta: KvStoreMetadata = minicbor::decode(&meta_cbor)
                 .map_err(|e| ManyError::deserialization_error(e.to_string()))?;

--- a/src/many-modules/src/_7_kvstore_commands/put.rs
+++ b/src/many-modules/src/_7_kvstore_commands/put.rs
@@ -7,7 +7,7 @@ use minicbor::{Decode, Encode};
 // `merk` doesn't support key size > 255 bytes.
 // Storage delimiter is 1 byte.
 const KVSTORE_KEY_MAX_SIZE: usize = 254;
-const KVSTORE_VALUE_MAX_SIZE: usize = 512000; // 512KiB
+const KVSTORE_VALUE_MAX_SIZE: usize = 524288; // 512KiB
 
 #[derive(Clone, Debug, Encode, Decode, Eq, PartialEq)]
 #[cbor(map)]

--- a/src/many-modules/src/_7_kvstore_commands/put.rs
+++ b/src/many-modules/src/_7_kvstore_commands/put.rs
@@ -4,8 +4,10 @@ use minicbor::bytes::ByteVec;
 use minicbor::data::Type;
 use minicbor::{Decode, Encode};
 
-const KVSTORE_KEY_MAX_SIZE: usize = 248; // size is u8 but storage is in "/store/" (7 bytes long);
-const KVSTORE_VALUE_MAX_SIZE: usize = 64000; // 64kB
+// `merk` doesn't support key size > 255 bytes.
+// Storage delimiter is 1 byte.
+const KVSTORE_KEY_MAX_SIZE: usize = 254;
+const KVSTORE_VALUE_MAX_SIZE: usize = 512000; // 512KiB
 
 #[derive(Clone, Debug, Encode, Decode, Eq, PartialEq)]
 #[cbor(map)]

--- a/tests/e2e/kvstore/kvstore.bats
+++ b/tests/e2e/kvstore/kvstore.bats
@@ -24,6 +24,45 @@ function teardown() {
   assert_output --partial "foobar"
 }
 
+@test "$SUITE: can put 254 bytes key" {
+  local key
+  key=$(openssl rand -hex 254)
+  call_kvstore --pem=1 --port=8000 put --hex-key "$key" "foobar"
+  call_kvstore --pem=1 --port=8000 get --hex-key "$key"
+  assert_output --partial "foobar"
+}
+
+@test "$SUITE: can't put 255 bytes key" {
+  local key
+  key=$(openssl rand -hex 255)
+  call_kvstore --pem=1 --port=8000 put --hex-key "$key" "foobar"
+  call_kvstore --pem=1 --port=8000 get --hex-key "$key"
+  refute_output --partial "foobar"
+}
+
+@test "$SUITE: can put 512KiB values" {
+  dd if=/dev/urandom of=upload_test_512 bs=512000 count=1
+  cat upload_test_512 | call_kvstore --pem=1 --port=8000 put --stdin "foo"
+  call_kvstore --pem=1 --port=8000 get "foo"
+  assert_output --partial "$(cat upload_test_512)"
+}
+
+@test "$SUITE: can't put 512KiB + 1 values" {
+  dd if=/dev/urandom of=upload_test_512_1 bs=512001 count=1
+  cat upload_test_512_1 | call_kvstore --pem=1 --port=8000 put --stdin "foo"
+  call_kvstore --pem=1 --port=8000 get "foo"
+  refute_output --partial "foo"
+}
+
+@test "$SUITE: can put 254 bytes key with 512KiB values" {
+  local key
+  key=$(openssl rand -hex 254)
+  dd if=/dev/urandom of=upload_test_512 bs=512000 count=1
+  cat upload_test_512 | call_kvstore --pem=1 --port=8000 put --stdin --hex-key "$key"
+  call_kvstore --pem=1 --port=8000 get --hex-key "$key"
+  assert_output --partial "$(cat upload_test_512)"
+}
+
 @test "$SUITE: can put and query data" {
   call_kvstore --pem=1 --port=8000 put "010203" "foobar"
   call_kvstore --pem=1 --port=8000 query "010203"

--- a/tests/e2e/kvstore/kvstore.bats
+++ b/tests/e2e/kvstore/kvstore.bats
@@ -41,14 +41,14 @@ function teardown() {
 }
 
 @test "$SUITE: can put 512KiB values" {
-  dd if=/dev/urandom of=upload_test_512 bs=512000 count=1
+  dd if=/dev/urandom of=upload_test_512 bs=524288 count=1
   cat upload_test_512 | call_kvstore --pem=1 --port=8000 put --stdin "foo"
   call_kvstore --pem=1 --port=8000 get "foo"
   assert_output --partial "$(cat upload_test_512)"
 }
 
 @test "$SUITE: can't put 512KiB + 1 values" {
-  dd if=/dev/urandom of=upload_test_512_1 bs=512001 count=1
+  dd if=/dev/urandom of=upload_test_512_1 bs=524289 count=1
   cat upload_test_512_1 | call_kvstore --pem=1 --port=8000 put --stdin "foo"
   call_kvstore --pem=1 --port=8000 get "foo"
   refute_output --partial "foo"
@@ -57,7 +57,7 @@ function teardown() {
 @test "$SUITE: can put 254 bytes key with 512KiB values" {
   local key
   key=$(openssl rand -hex 254)
-  dd if=/dev/urandom of=upload_test_512 bs=512000 count=1
+  dd if=/dev/urandom of=upload_test_512 bs=524288 count=1
   cat upload_test_512 | call_kvstore --pem=1 --port=8000 put --stdin --hex-key "$key"
   call_kvstore --pem=1 --port=8000 get --hex-key "$key"
   assert_output --partial "$(cat upload_test_512)"

--- a/tests/resiliency/kvstore/limits.bats
+++ b/tests/resiliency/kvstore/limits.bats
@@ -1,0 +1,42 @@
+GIT_ROOT="$BATS_TEST_DIRNAME/../../../"
+MAKEFILE="Makefile.kvstore"
+
+load '../../test_helper/load'
+load '../../test_helper/kvstore'
+
+function setup() {
+    load "test_helper/bats-assert/load"
+    load "test_helper/bats-support/load"
+
+    mkdir "$BATS_TEST_ROOTDIR"
+
+    (
+      cd "$GIT_ROOT/docker/" || exit
+      make -f $MAKEFILE clean
+      make -f $MAKEFILE start-nodes-detached || {
+        echo '# Could not start nodes...' >&3
+        exit 1
+      }
+    ) > /dev/null
+
+    # Give time to the servers to start.
+    wait_for_server 8000 8001 8002 8003
+}
+
+function teardown() {
+    (
+      cd "$GIT_ROOT/docker/" || exit 1
+      make -f $MAKEFILE stop-nodes
+    ) 2> /dev/null
+
+    # Fix for BATS verbose run/test output gathering
+    cd "$GIT_ROOT/tests/resiliency/kvstore" || exit 1
+}
+
+@test "$SUITE: can put 254 bytes key with 512KiB values" {
+    local key
+    key=$(openssl rand -hex 254)
+    dd if=/dev/urandom of=upload_test_512 bs=512000 count=1
+    cat upload_test_512 | call_kvstore --pem=1 --port=8000 put --stdin --hex-key "$key"
+    check_consistency_value_from_file --pem=1 --key="$key" --file="upload_test_512" 8000 8001 8002 8003
+}

--- a/tests/resiliency/kvstore/limits.bats
+++ b/tests/resiliency/kvstore/limits.bats
@@ -36,7 +36,7 @@ function teardown() {
 @test "$SUITE: can put 254 bytes key with 512KiB values" {
     local key
     key=$(openssl rand -hex 254)
-    dd if=/dev/urandom of=upload_test_512 bs=512000 count=1
+    dd if=/dev/urandom of=upload_test_512 bs=524288 count=1
     cat upload_test_512 | call_kvstore --pem=1 --port=8000 put --stdin --hex-key "$key"
     check_consistency_value_from_file --pem=1 --key="$key" --file="upload_test_512" 8000 8001 8002 8003
 }

--- a/tests/test_helper/kvstore.bash
+++ b/tests/test_helper/kvstore.bash
@@ -70,3 +70,25 @@ function check_consistency() {
         assert_output --partial "$expected_value"
     done
 }
+
+function check_consistency_value_from_file() {
+    local pem_arg
+    local key
+    local expected_value
+
+    while (( $# > 0 )); do
+      case "$1" in
+        --pem=*) pem_arg=${1}; shift ;;
+        --key=*) key=${1#--key=}; shift ;;
+        --file=*) expected_value=${1#--file=}; shift;;
+        --) shift; break ;;
+        *) break ;;
+      esac
+    done
+
+    for port in "$@"; do
+        # Named parameters that can be empty need to be located after those who can't
+        call_kvstore --port="$port" "$pem_arg" get "$key"
+        assert_output --partial "$(cat expected_value)"
+    done
+}


### PR DESCRIPTION
This PR updates the `merk` version used by the kvstore to allow value size larger than 64KiB.

The new limits are
- Key: 254 bytes (1 byte used for delimiter)
- Value: 512KiB

Fixes #346

Note: The `merk` version used in `ledger` is unchanged; only `kvstore` is affected by the update.
Note2: `merk` still limits the key length to 255 bytes even if the underlying storage supports more. Not sure why but this is out of the scope of this PR.