### PR TITLE
ci: disable macos nightly for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -646,24 +646,24 @@ workflows:
                 os: linux2204_machine
           test_name: << pipeline.parameters.test_name >>
 
-  nightly_macos:
-    when:
-      and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ "macOS nightly", << pipeline.schedule.name >> ]
-    jobs:
-      - lint-test-build:
-          pre-steps:
-            - install-deps:
-                os: << matrix.os >>
-          name: lint-test-build-v<< matrix.os >>
-          matrix:
-            parameters:
-              os: [macos]
-      - tag:
-          name: macos nightly tag
-          tag: macos-green
-          context:
-            - GITHUB_CREDS
-          requires:
-            - lint-test-build-vmacos
+#  nightly_macos:
+#    when:
+#      and:
+#        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+#        - equal: [ "macOS nightly", << pipeline.schedule.name >> ]
+#    jobs:
+#      - lint-test-build:
+#          pre-steps:
+#            - install-deps:
+#                os: << matrix.os >>
+#          name: lint-test-build-v<< matrix.os >>
+#          matrix:
+#            parameters:
+#              os: [macos]
+#      - tag:
+#          name: macos nightly tag
+#          tag: macos-green
+#          context:
+#            - GITHUB_CREDS
+#          requires:
+#            - lint-test-build-vmacos


### PR DESCRIPTION
macos nightly is failing and I don't know why. I don't have access to a macos system so I'm disabling this build for now.